### PR TITLE
Fix LazyDatabase implementation

### DIFF
--- a/lib/data/datasources/local/app_database.dart
+++ b/lib/data/datasources/local/app_database.dart
@@ -21,7 +21,13 @@ class AppDatabase extends _$AppDatabase {
 }
 
 LazyDatabase _openConnection() {
-  // ... (fungsi ini tetap sama)
+  return LazyDatabase(
+    () async {
+      final dbFolder = await getApplicationDocumentsDirectory();
+      final file = File(p.join(dbFolder.path, 'db.sqlite'));
+      return NativeDatabase(file);
+    },
+  );
 }
 
 // PASTIKAN KELAS DatabaseModule DI BAWAH INI SUDAH DIHAPUS


### PR DESCRIPTION
## Summary
- implement a real `_openConnection` that returns a `LazyDatabase`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f34f88f248324894c32aad96159d9