### PR TITLE
Fix journal DAO import and DI registration

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -41,7 +41,7 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i847.JournalRepository>(
       () => _i625.JournalRepositoryImpl(
         gh<_i1020.JournalApiService>(),
-        gh<InvalidType>(),
+        gh<_i28.JournalDao>(),
       ),
     );
     gh.factory<_i738.GetJournalsUseCase>(

--- a/lib/data/repositories/journal_repository_impl.dart
+++ b/lib/data/repositories/journal_repository_impl.dart
@@ -1,6 +1,7 @@
 // lib/data/repositories/journal_repository_impl.dart
 
 import 'package:dear_flutter/data/datasources/local/app_database.dart';
+import 'package:dear_flutter/data/datasources/local/journal_dao.dart';
 import 'package:dear_flutter/domain/entities/journal.dart';
 import 'package:dear_flutter/domain/repositories/journal_repository.dart';
 import 'package:dear_flutter/data/datasources/remote/journal_api_service.dart';


### PR DESCRIPTION
## Summary
- add missing JournalDao import in `JournalRepositoryImpl`
- register `JournalRepositoryImpl` with `JournalDao` in generated config

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685faceedbcc832497e6d7d050176f71