### PR TITLE
Update widget test to smoke test HomeScreen

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,24 +7,37 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:dear_flutter/main.dart';
+import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_state.dart';
+
+class _FakeHomeCubit extends Cubit<HomeState> implements HomeCubit {
+  _FakeHomeCubit() : super(const HomeState());
+
+  @override
+  Future<void> syncJournals() async {}
+
+  @override
+  void watchJournals() {}
+}
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  final getIt = GetIt.instance;
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  setUp(() {
+    getIt.reset();
+    getIt.registerFactory<HomeCubit>(() => _FakeHomeCubit());
+  });
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+  tearDown(getIt.reset);
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('HomeScreen renders without error', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+
+    expect(find.byType(HomeScreen), findsOneWidget);
+    expect(find.text('Beranda'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- replace counter sample test with a smoke test that pumps `HomeScreen`
- register a fake `HomeCubit` so the screen builds without real dependencies

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fda0a03848324beb526dbe205b870