### PR TITLE
Fix trailing slash for journal API

### DIFF
--- a/lib/data/datasources/remote/journal_api_service.dart
+++ b/lib/data/datasources/remote/journal_api_service.dart
@@ -12,7 +12,10 @@ class JournalApiService {
   JournalApiService(this._dio);
 
   Future<List<Journal>> getJournals() async {
-    final response = await _dio.get('journals');
+    // Some backends require a trailing slash and will respond with a redirect
+    // if it is missing. Using the correct path avoids an extra request and
+    // ensures `response.data` is in the expected JSON format.
+    final response = await _dio.get('journals/');
     return (response.data as List)
         .map((json) => Journal.fromJson(json))
         .toList();
@@ -20,7 +23,7 @@ class JournalApiService {
 
   Future<Journal> createJournal(CreateJournalRequest request) async {
     final response = await _dio.post(
-      'journals',
+      'journals/',
       data: request.toJson(),
     );
     return Journal.fromJson(response.data);


### PR DESCRIPTION
## Summary
- avoid redirect when calling the journal API by appending trailing slashes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe917ddb48324b48eac5013957a03