### PR TITLE
Initialize dependencies asynchronously

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -12,4 +12,4 @@ final getIt = GetIt.instance;
   preferRelativeImports: true, // default
   asExtension: true, // default
 )
-void configureDependencies() => getIt.init();
+Future<GetIt> configureDependencies() => getIt.init();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,12 +4,12 @@ import 'package:flutter/material.dart';
 import 'package:dear_flutter/core/di/injection.dart';
 import 'package:dear_flutter/presentation/auth/screens/login_screen.dart'; // <-- Import login screen
 
-void main() {
+Future<void> main() async {
   // Pastikan jembatan ke platform asli sudah siap
   WidgetsFlutterBinding.ensureInitialized();
 
   // Inisialisasi dependency injection
-  configureDependencies();
+  await configureDependencies();
 
   runApp(const MyApp());
 }


### PR DESCRIPTION
## Summary
- return a `Future<GetIt>` from `configureDependencies`
- make `main` async and await the initializer

## Testing
- `flutter analyze` *(fails: `flutter` command not found)*
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff64ececc83249a77f8ecd5e8b6ab