### PR TITLE
Switch journal IDs to integers

### DIFF
--- a/lib/data/datasources/local/app_database.g.dart
+++ b/lib/data/datasources/local/app_database.g.dart
@@ -11,11 +11,11 @@ class $JournalEntriesTable extends JournalEntries
   $JournalEntriesTable(this.attachedDatabase, [this._alias]);
   static const VerificationMeta _idMeta = const VerificationMeta('id');
   @override
-  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
     'id',
     aliasedName,
     false,
-    type: DriftSqlType.string,
+    type: DriftSqlType.int,
     requiredDuringInsert: true,
   );
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
@@ -190,7 +190,7 @@ class $JournalEntriesTable extends JournalEntries
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return JournalEntry(
       id: attachedDatabase.typeMapping.read(
-        DriftSqlType.string,
+        DriftSqlType.int,
         data['${effectivePrefix}id'],
       )!,
       title: attachedDatabase.typeMapping.read(
@@ -231,7 +231,7 @@ class $JournalEntriesTable extends JournalEntries
 }
 
 class JournalEntry extends DataClass implements Insertable<JournalEntry> {
-  final String id;
+  final int id;
   final String title;
   final String content;
   final String mood;
@@ -252,7 +252,7 @@ class JournalEntry extends DataClass implements Insertable<JournalEntry> {
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
-    map['id'] = Variable<String>(id);
+    map['id'] = Variable<int>(id);
     map['title'] = Variable<String>(title);
     map['content'] = Variable<String>(content);
     map['mood'] = Variable<String>(mood);
@@ -290,7 +290,7 @@ class JournalEntry extends DataClass implements Insertable<JournalEntry> {
   }) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return JournalEntry(
-      id: serializer.fromJson<String>(json['id']),
+      id: serializer.fromJson<int>(json['id']),
       title: serializer.fromJson<String>(json['title']),
       content: serializer.fromJson<String>(json['content']),
       mood: serializer.fromJson<String>(json['mood']),
@@ -304,7 +304,7 @@ class JournalEntry extends DataClass implements Insertable<JournalEntry> {
   Map<String, dynamic> toJson({ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
-      'id': serializer.toJson<String>(id),
+      'id': serializer.toJson<int>(id),
       'title': serializer.toJson<String>(title),
       'content': serializer.toJson<String>(content),
       'mood': serializer.toJson<String>(mood),
@@ -316,7 +316,7 @@ class JournalEntry extends DataClass implements Insertable<JournalEntry> {
   }
 
   JournalEntry copyWith({
-    String? id,
+    int? id,
     String? title,
     String? content,
     String? mood,
@@ -396,7 +396,7 @@ class JournalEntry extends DataClass implements Insertable<JournalEntry> {
 }
 
 class JournalEntriesCompanion extends UpdateCompanion<JournalEntry> {
-  final Value<String> id;
+  final Value<int> id;
   final Value<String> title;
   final Value<String> content;
   final Value<String> mood;
@@ -417,7 +417,7 @@ class JournalEntriesCompanion extends UpdateCompanion<JournalEntry> {
     this.rowid = const Value.absent(),
   });
   JournalEntriesCompanion.insert({
-    required String id,
+    required int id,
     required String title,
     required String content,
     required String mood,
@@ -433,7 +433,7 @@ class JournalEntriesCompanion extends UpdateCompanion<JournalEntry> {
        createdAt = Value(createdAt),
        isSynced = Value(isSynced);
   static Insertable<JournalEntry> custom({
-    Expression<String>? id,
+    Expression<int>? id,
     Expression<String>? title,
     Expression<String>? content,
     Expression<String>? mood,
@@ -457,7 +457,7 @@ class JournalEntriesCompanion extends UpdateCompanion<JournalEntry> {
   }
 
   JournalEntriesCompanion copyWith({
-    Value<String>? id,
+    Value<int>? id,
     Value<String>? title,
     Value<String>? content,
     Value<String>? mood,
@@ -484,7 +484,7 @@ class JournalEntriesCompanion extends UpdateCompanion<JournalEntry> {
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     if (id.present) {
-      map['id'] = Variable<String>(id.value);
+      map['id'] = Variable<int>(id.value);
     }
     if (title.present) {
       map['title'] = Variable<String>(title.value);
@@ -959,7 +959,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
 
 typedef $$JournalEntriesTableCreateCompanionBuilder =
     JournalEntriesCompanion Function({
-      required String id,
+      required int id,
       required String title,
       required String content,
       required String mood,
@@ -971,7 +971,7 @@ typedef $$JournalEntriesTableCreateCompanionBuilder =
     });
 typedef $$JournalEntriesTableUpdateCompanionBuilder =
     JournalEntriesCompanion Function({
-      Value<String> id,
+      Value<int> id,
       Value<String> title,
       Value<String> content,
       Value<String> mood,
@@ -1152,8 +1152,8 @@ class $$JournalEntriesTableTableManager
           createComputedFieldComposer: () =>
               $$JournalEntriesTableAnnotationComposer($db: db, $table: table),
           updateCompanionCallback:
-              ({
-                Value<String> id = const Value.absent(),
+                ({
+                  Value<int> id = const Value.absent(),
                 Value<String> title = const Value.absent(),
                 Value<String> content = const Value.absent(),
                 Value<String> mood = const Value.absent(),
@@ -1175,7 +1175,7 @@ class $$JournalEntriesTableTableManager
               ),
           createCompanionCallback:
               ({
-                required String id,
+                required int id,
                 required String title,
                 required String content,
                 required String mood,

--- a/lib/data/datasources/local/journal_dao.dart
+++ b/lib/data/datasources/local/journal_dao.dart
@@ -13,12 +13,12 @@ class JournalDao extends DatabaseAccessor<AppDatabase> with _$JournalDaoMixin {
   Stream<List<JournalEntry>> watchAllJournals() =>
       (select(journalEntries)..orderBy([(t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc)])).watch();
 
-  Stream<JournalEntry?> watchJournalById(String id) =>
+  Stream<JournalEntry?> watchJournalById(int id) =>
       (select(journalEntries)..where((tbl) => tbl.id.equals(id))).watchSingleOrNull();
 
   Future<void> insertJournal(JournalEntry journal) =>
       into(journalEntries).insert(journal, mode: InsertMode.replace);
 
-  Future<void> deleteJournalById(String id) =>
+  Future<void> deleteJournalById(int id) =>
       (delete(journalEntries)..where((tbl) => tbl.id.equals(id))).go();
 }

--- a/lib/data/models/tables.dart
+++ b/lib/data/models/tables.dart
@@ -5,7 +5,7 @@ import 'package:drift/drift.dart';
 // Tabel ini adalah padanan dari JournalEntity.kt
 class JournalEntries extends Table {
   // Kolom-kolomnya
-  TextColumn get id => text()();
+  IntColumn get id => integer()();
   TextColumn get title => text()();
   TextColumn get content => text()();
   TextColumn get mood => text()();

--- a/lib/domain/entities/journal.dart
+++ b/lib/domain/entities/journal.dart
@@ -12,7 +12,7 @@ class Journal with _$Journal {
   // Konstruktor factory ini mendefinisikan struktur data kita.
   // Ini mirip dengan properti di data class Kotlin Anda.
   const factory Journal({
-    required String id,
+    required int id,
     required String title,
     required String content,
     required String mood,

--- a/lib/domain/entities/journal.freezed.dart
+++ b/lib/domain/entities/journal.freezed.dart
@@ -21,7 +21,7 @@ Journal _$JournalFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$Journal {
-  String get id => throw _privateConstructorUsedError;
+  int get id => throw _privateConstructorUsedError;
   String get title => throw _privateConstructorUsedError;
   String get content => throw _privateConstructorUsedError;
   String get mood =>
@@ -46,7 +46,7 @@ abstract class $JournalCopyWith<$Res> {
       _$JournalCopyWithImpl<$Res, Journal>;
   @useResult
   $Res call({
-    String id,
+    int id,
     String title,
     String content,
     String mood,
@@ -80,7 +80,7 @@ class _$JournalCopyWithImpl<$Res, $Val extends Journal>
             id: null == id
                 ? _value.id
                 : id // ignore: cast_nullable_to_non_nullable
-                      as String,
+                      as int,
             title: null == title
                 ? _value.title
                 : title // ignore: cast_nullable_to_non_nullable
@@ -112,7 +112,7 @@ abstract class _$$JournalImplCopyWith<$Res> implements $JournalCopyWith<$Res> {
   @override
   @useResult
   $Res call({
-    String id,
+    int id,
     String title,
     String content,
     String mood,
@@ -145,7 +145,7 @@ class __$$JournalImplCopyWithImpl<$Res>
         id: null == id
             ? _value.id
             : id // ignore: cast_nullable_to_non_nullable
-                  as String,
+                  as int,
         title: null == title
             ? _value.title
             : title // ignore: cast_nullable_to_non_nullable
@@ -182,7 +182,7 @@ class _$JournalImpl implements _Journal {
       _$$JournalImplFromJson(json);
 
   @override
-  final String id;
+  final int id;
   @override
   final String title;
   @override
@@ -235,7 +235,7 @@ class _$JournalImpl implements _Journal {
 
 abstract class _Journal implements Journal {
   const factory _Journal({
-    required final String id,
+    required final int id,
     required final String title,
     required final String content,
     required final String mood,
@@ -245,7 +245,7 @@ abstract class _Journal implements Journal {
   factory _Journal.fromJson(Map<String, dynamic> json) = _$JournalImpl.fromJson;
 
   @override
-  String get id;
+  int get id;
   @override
   String get title;
   @override

--- a/lib/domain/entities/journal.g.dart
+++ b/lib/domain/entities/journal.g.dart
@@ -8,7 +8,7 @@ part of 'journal.dart';
 
 _$JournalImpl _$$JournalImplFromJson(Map<String, dynamic> json) =>
     _$JournalImpl(
-      id: json['id'] as String,
+      id: json['id'] as int,
       title: json['title'] as String,
       content: json['content'] as String,
       mood: json['mood'] as String,


### PR DESCRIPTION
## Summary
- use `int` IDs in `Journal` entity and drift table
- update DAO methods for integer IDs
- regenerate code for entity and database

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686010f999dc8324bf54a90c9522bb2a