### PR TITLE
Remove redundant watchJournals call

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -13,7 +13,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => getIt<HomeCubit>()..watchJournals(), // Menjalankan pemantauan jurnal
+      create: (context) => getIt<HomeCubit>(),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Beranda'),


### PR DESCRIPTION
## Summary
- remove explicit `watchJournals()` call from `HomeScreen`
- `HomeCubit` already starts journal watching in its constructor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860136b03e48324a69ca2d2d60ed036