### PR TITLE
Clarify monitoring comment in HomeScreen

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -13,6 +13,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
+      // HomeCubit automatically starts monitoring journals
       create: (context) => getIt<HomeCubit>(),
       child: Scaffold(
         appBar: AppBar(


### PR DESCRIPTION
## Summary
- update BlocProvider comment to note that HomeCubit begins monitoring journals

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686019b3157083248bdefd9223000a5b