### PR TITLE
Fix CRUD removal helper and expose modules

### DIFF
--- a/backend/app/crud/__init__.py
+++ b/backend/app/crud/__init__.py
@@ -1,0 +1,24 @@
+from .crud_user import user, CRUDUser
+from .crud_article import article, CRUDArticle
+from .crud_journal import journal, CRUDJournal
+from .crud_chat import chat_message, CRUDChatMessage
+from .crud_audio import audio_track, CRUDAudioTrack
+from .crud_motivational_quote import motivational_quote, CRUDMotivationalQuote
+from .crud_user_profile import user_profile, CRUDUserProfile
+
+__all__ = [
+    "user",
+    "CRUDUser",
+    "article",
+    "CRUDArticle",
+    "journal",
+    "CRUDJournal",
+    "chat_message",
+    "CRUDChatMessage",
+    "audio_track",
+    "CRUDAudioTrack",
+    "motivational_quote",
+    "CRUDMotivationalQuote",
+    "user_profile",
+    "CRUDUserProfile",
+]

--- a/backend/app/crud/base.py
+++ b/backend/app/crud/base.py
@@ -54,7 +54,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
         return db_obj
 
     def remove(self, db: Session, *, id: int) -> Optional[ModelType]:
-        obj = db.query(self.model).get(id)
+        obj = db.get(self.model, id)
         if obj:
             db.delete(obj)
             db.commit()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,17 @@
+from .user import User
+from .user_profile import UserProfile
+from .chat import ChatMessage
+from .journal import Journal
+from .article import Article
+from .audio import AudioTrack
+from .motivational_quote import MotivationalQuote
+
+__all__ = [
+    "User",
+    "UserProfile",
+    "ChatMessage",
+    "Journal",
+    "Article",
+    "AudioTrack",
+    "MotivationalQuote",
+]

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,64 @@
+from .user import UserBase, UserCreate, UserUpdate, UserInDB, UserPublic, UserLogin
+from .token import Token, TokenPayload
+from .chat import (
+    ChatMessageBase,
+    ChatMessageCreate,
+    ChatMessageUpdate,
+    ChatFlagUpdate,
+    ChatMessageInDBBase,
+    ChatMessage,
+    ChatRequest,
+)
+from .article import ArticleBase, ArticleCreate, ArticleUpdate, Article
+from .journal import JournalBase, JournalCreate, JournalUpdate, JournalInDB
+from .journal import JournalInDB as Journal
+from .user_profile import UserProfileBase, UserProfileUpdate, UserProfile, UserProfileInDB
+from .audio import AudioTrackBase, AudioTrackCreate, AudioTrackUpdate, AudioTrack
+from .motivational_quote import (
+    MotivationalQuoteBase,
+    MotivationalQuoteCreate,
+    MotivationalQuoteUpdate,
+    MotivationalQuote,
+)
+from .plan import ConversationPlan, CommunicationTechnique
+
+__all__ = [
+    "UserBase",
+    "UserCreate",
+    "UserUpdate",
+    "UserInDB",
+    "UserPublic",
+    "UserLogin",
+    "Token",
+    "TokenPayload",
+    "ChatMessageBase",
+    "ChatMessageCreate",
+    "ChatMessageUpdate",
+    "ChatFlagUpdate",
+    "ChatMessageInDBBase",
+    "ChatMessage",
+    "ChatRequest",
+    "ArticleBase",
+    "ArticleCreate",
+    "ArticleUpdate",
+    "Article",
+    "JournalBase",
+    "JournalCreate",
+    "JournalUpdate",
+    "Journal",
+    "JournalInDB",
+    "UserProfileBase",
+    "UserProfileUpdate",
+    "UserProfile",
+    "UserProfileInDB",
+    "AudioTrackBase",
+    "AudioTrackCreate",
+    "AudioTrackUpdate",
+    "AudioTrack",
+    "MotivationalQuoteBase",
+    "MotivationalQuoteCreate",
+    "MotivationalQuoteUpdate",
+    "MotivationalQuote",
+    "ConversationPlan",
+    "CommunicationTechnique",
+]


### PR DESCRIPTION
## Summary
- use `db.get()` inside `CRUDBase.remove`
- expose model and crud objects via `__init__` modules so tests import correctly

## Testing
- `pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_686040a0e3bc83249612afa12c59ddca