### PR TITLE
Add profile analysis scheduling on journal creation

### DIFF
--- a/backend/app/api/v1/journal.py
+++ b/backend/app/api/v1/journal.py
@@ -24,8 +24,10 @@ def create_journal(
 
     journal = crud.journal.create_with_owner(db=db, obj_in=journal_in, owner_id=current_user.id)
 
+    background_tasks.add_task(analyze_profile_task, current_user.id)
+
     log.info(
-        "Jurnal dibuat, penjadwalan analisis ditangguhkan sementara",
+        "Jurnal dibuat",
         user_id=current_user.id,
         journal_id=journal.id,
     )

--- a/backend/tests/test_journal_api.py
+++ b/backend/tests/test_journal_api.py
@@ -1,0 +1,26 @@
+import app.api.v1.journal as journal_api
+from fastapi.background import BackgroundTasks
+
+
+def test_create_journal_schedules_analysis(client, monkeypatch):
+    client_app, _ = client
+    captured = {}
+
+    def fake_add_task(self, func, *args, **kwargs):
+        captured['func'] = func
+        captured['args'] = args
+        captured['kwargs'] = kwargs
+
+    monkeypatch.setattr(BackgroundTasks, 'add_task', fake_add_task)
+
+    dummy_task = lambda user_id: None
+    monkeypatch.setattr(journal_api, 'analyze_profile_task', dummy_task)
+
+    resp = client_app.post(
+        '/api/v1/journals/',
+        json={'title': 't', 'content': 'c', 'mood': 'ok'}
+    )
+    assert resp.status_code == 200
+    assert captured['func'] is dummy_task
+    assert captured['args'][0] == 1
+


### PR DESCRIPTION
## Summary
- trigger `analyze_profile_task` when creating a journal
- remove the postponed-analysis log text
- test that background task is scheduled on journal creation

## Testing
- `pip install -q -r backend/requirements.txt`
- `export SPOTIFY_CLIENT_ID=test SPOTIFY_CLIENT_SECRET=test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686042de7d40832488a5733446f09450