### PR TITLE
Add lazy Spotify client init with 503 on missing creds

### DIFF
--- a/backend/tests/test_music_api.py
+++ b/backend/tests/test_music_api.py
@@ -3,6 +3,8 @@
 import pytest
 from unittest.mock import AsyncMock
 from spotipy import Spotify
+from app.core.config import settings
+from app.api.v1 import music
 
 from app import crud
 from app.models.journal import Journal
@@ -10,6 +12,9 @@ from app.services.music_keyword_service import MusicKeywordService
 
 
 def test_music_endpoint_returns_list(client, monkeypatch):
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_ID", "id")
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_SECRET", "secret")
+    monkeypatch.setattr(music, "spotify", None)
     # Return fake Spotify search payload
     def fake_search(self, q, type="track", limit=20):
         return {"tracks": {"items": [{"name": "Song", "id": "abc123"}]}}
@@ -27,6 +32,9 @@ def test_music_endpoint_returns_list(client, monkeypatch):
 
 
 def test_music_recommend_uses_keyword_and_journals(client, monkeypatch):
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_ID", "id")
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_SECRET", "secret")
+    monkeypatch.setattr(music, "spotify", None)
     captured = {}
 
     # --- PERBAIKAN 2: Menambahkan `order_by` ke mock ---
@@ -57,6 +65,9 @@ def test_music_recommend_uses_keyword_and_journals(client, monkeypatch):
 
 
 def test_music_recommend_returns_empty_list_when_no_results(client, monkeypatch):
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_ID", "id")
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_SECRET", "secret")
+    monkeypatch.setattr(music, "spotify", None)
     # --- PERBAIKAN 3: Menambahkan `order_by` ke mock ---
     def fake_get_multi_by_owner(db, owner_id: int, skip: int = 0, limit: int = 100, order_by: str = None):
         # Mengembalikan jurnal untuk memicu logika fallback
@@ -77,4 +88,13 @@ def test_music_recommend_returns_empty_list_when_no_results(client, monkeypatch)
     resp = client_app.get("/api/v1/music/recommend")
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+def test_music_endpoint_returns_503_without_credentials(client, monkeypatch):
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_ID", None)
+    monkeypatch.setattr(settings, "SPOTIFY_CLIENT_SECRET", None)
+    monkeypatch.setattr(music, "spotify", None)
+    client_app, _ = client
+    resp = client_app.get("/api/v1/music?mood=test")
+    assert resp.status_code == 503
 


### PR DESCRIPTION
## Summary
- lazily initialize Spotify client in API handlers
- check credentials on each request
- return HTTP 503 if credentials are missing
- update tests for new credential handling

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686043ef0b9c8324a0434cd206aced30