### PR TITLE
Add placeholder screens for chat and main navigation

### DIFF
--- a/lib/presentation/chat/screens/chat_screen.dart
+++ b/lib/presentation/chat/screens/chat_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ChatScreen extends StatelessWidget {
+  const ChatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Chat')),
+      body: const Center(child: Text('Coming soon...')),
+    );
+  }
+}

--- a/lib/presentation/main/main_screen.dart
+++ b/lib/presentation/main/main_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class MainScreen extends StatelessWidget {
+  final StatefulNavigationShell child;
+  const MainScreen({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: child,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: child.currentIndex,
+        onDestinationSelected: child.goBranch,
+        destinations: const [
+          NavigationDestination(icon: Icon(Icons.home), label: 'Home'),
+          NavigationDestination(icon: Icon(Icons.chat), label: 'Chat'),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MainScreen` wrapper with bottom navigation
- add a placeholder `ChatScreen`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68604e47b37483248a672a3e8ca3fa9c