### PR TITLE
Add delete account feature

### DIFF
--- a/backend/app/api/v1/user.py
+++ b/backend/app/api/v1/user.py
@@ -1,10 +1,21 @@
 from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
 
-from app import models, schemas
-from app.dependencies import get_current_user
+from app import crud, models, schemas
+from app.dependencies import get_current_user, get_db
 
 router = APIRouter()
 
 @router.get("/users/me", response_model=schemas.UserPublic)
 def read_users_me(current_user: models.User = Depends(get_current_user)):
     return current_user
+
+
+@router.delete("/users/me", response_model=schemas.UserPublic)
+def delete_user_me(
+    *,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+):
+    user = crud.user.remove(db=db, id=current_user.id)
+    return user

--- a/backend/tests/test_user_api.py
+++ b/backend/tests/test_user_api.py
@@ -10,3 +10,16 @@ def test_get_current_user(client):
     assert data["email"] == "tester@example.com"
     assert data["id"] == 1
 
+
+def test_delete_current_user(client):
+    client_app, session_local = client
+    resp = client_app.delete("/api/v1/users/me")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == 1
+    db = session_local()
+    try:
+        assert db.query(User).filter_by(id=1).first() is None
+    finally:
+        db.close()
+

--- a/lib/data/datasources/remote/user_api_service.dart
+++ b/lib/data/datasources/remote/user_api_service.dart
@@ -12,4 +12,8 @@ class UserApiService {
     final response = await _dio.get('users/me');
     return User.fromJson(response.data);
   }
+
+  Future<void> deleteAccount() async {
+    await _dio.delete('users/me');
+  }
 }

--- a/lib/data/repositories/auth_repository_impl.dart
+++ b/lib/data/repositories/auth_repository_impl.dart
@@ -49,4 +49,10 @@ class AuthRepositoryImpl implements AuthRepository {
     // Teruskan panggilan ke UserApiService
     return _userApiService.getProfile();
   }
+
+  @override
+  Future<void> deleteAccount() async {
+    await _userApiService.deleteAccount();
+    await _prefs.clearAuthToken();
+  }
 }

--- a/lib/domain/repositories/auth_repository.dart
+++ b/lib/domain/repositories/auth_repository.dart
@@ -6,5 +6,6 @@ abstract class AuthRepository {
   Future<void> register(RegisterRequest request);
   Future<void> logout();
   bool isLoggedIn();
-  Future<User> getProfile(); 
+  Future<User> getProfile();
+  Future<void> deleteAccount();
 }

--- a/lib/domain/usecases/delete_account_usecase.dart
+++ b/lib/domain/usecases/delete_account_usecase.dart
@@ -1,0 +1,10 @@
+import 'package:dear_flutter/domain/repositories/auth_repository.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class DeleteAccountUseCase {
+  final AuthRepository _repository;
+  DeleteAccountUseCase(this._repository);
+
+  Future<void> call() => _repository.deleteAccount();
+}

--- a/lib/presentation/profile/cubit/profile_cubit.dart
+++ b/lib/presentation/profile/cubit/profile_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:dear_flutter/domain/usecases/get_user_profile_usecase.dart';
 import 'package:dear_flutter/domain/usecases/logout_usecase.dart';
+import 'package:dear_flutter/domain/usecases/delete_account_usecase.dart';
 import 'package:dear_flutter/presentation/profile/cubit/profile_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
@@ -8,9 +9,13 @@ import 'package:injectable/injectable.dart';
 class ProfileCubit extends Cubit<ProfileState> {
   final GetUserProfileUseCase _getUserProfileUseCase;
   final LogoutUseCase _logoutUseCase;
+  final DeleteAccountUseCase _deleteAccountUseCase;
 
-  ProfileCubit(this._getUserProfileUseCase, this._logoutUseCase)
-      : super(const ProfileState()) {
+  ProfileCubit(
+      this._getUserProfileUseCase,
+      this._logoutUseCase,
+      this._deleteAccountUseCase,
+      ) : super(const ProfileState()) {
     fetchUserProfile();
   }
 
@@ -26,5 +31,9 @@ class ProfileCubit extends Cubit<ProfileState> {
 
   Future<void> logout() async {
     await _logoutUseCase();
+  }
+
+  Future<void> deleteAccount() async {
+    await _deleteAccountUseCase();
   }
 }

--- a/lib/presentation/profile/screens/profile_screen.dart
+++ b/lib/presentation/profile/screens/profile_screen.dart
@@ -42,6 +42,21 @@ class ProfileScreen extends StatelessWidget {
                     const SizedBox(height: 8),
                     Text(user.email, style: Theme.of(context).textTheme.bodyLarge),
                     const Spacer(),
+                    ElevatedButton(
+                      onPressed: () async {
+                        await context.read<ProfileCubit>().deleteAccount();
+                        if (context.mounted) {
+                          context.go('/login');
+                        }
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red.shade100,
+                        foregroundColor: Colors.red.shade900,
+                        minimumSize: const Size(double.infinity, 50),
+                      ),
+                      child: const Text('Hapus Akun'),
+                    ),
+                    const SizedBox(height: 12),
                     ElevatedButton.icon(
                       onPressed: () async {
                         await context.read<ProfileCubit>().logout();

--- a/test/delete_account_usecase_test.dart
+++ b/test/delete_account_usecase_test.dart
@@ -1,0 +1,40 @@
+import 'package:dear_flutter/domain/repositories/auth_repository.dart';
+import 'package:dear_flutter/domain/usecases/delete_account_usecase.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dear_flutter/data/models/requests.dart';
+import 'package:dear_flutter/domain/entities/user.dart';
+
+class _FakeAuthRepository implements AuthRepository {
+  bool called = false;
+
+  @override
+  Future<void> deleteAccount() async {
+    called = true;
+  }
+
+  @override
+  Future<void> login(LoginRequest request) async {}
+
+  @override
+  Future<void> register(RegisterRequest request) async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  bool isLoggedIn() => false;
+
+  @override
+  Future<User> getProfile() async => const User(id: '1', username: 'u', email: 'e');
+}
+
+void main() {
+  test('DeleteAccountUseCase calls repository', () async {
+    final repo = _FakeAuthRepository();
+    final usecase = DeleteAccountUseCase(repo);
+
+    await usecase();
+
+    expect(repo.called, isTrue);
+  });
+}

--- a/test/profile_cubit_test.dart
+++ b/test/profile_cubit_test.dart
@@ -1,0 +1,47 @@
+import 'package:dear_flutter/data/models/requests.dart';
+import 'package:dear_flutter/domain/entities/user.dart';
+import 'package:dear_flutter/domain/repositories/auth_repository.dart';
+import 'package:dear_flutter/domain/usecases/delete_account_usecase.dart';
+import 'package:dear_flutter/domain/usecases/get_user_profile_usecase.dart';
+import 'package:dear_flutter/domain/usecases/logout_usecase.dart';
+import 'package:dear_flutter/presentation/profile/cubit/profile_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeAuthRepository implements AuthRepository {
+  bool deleteCalled = false;
+
+  @override
+  Future<void> deleteAccount() async {
+    deleteCalled = true;
+  }
+
+  @override
+  Future<void> login(LoginRequest request) async {}
+
+  @override
+  Future<void> register(RegisterRequest request) async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  bool isLoggedIn() => true;
+
+  @override
+  Future<User> getProfile() async => const User(id: '1', username: 'u', email: 'e');
+}
+
+void main() {
+  test('ProfileCubit.deleteAccount delegates to use case', () async {
+    final repo = _FakeAuthRepository();
+    final cubit = ProfileCubit(
+      GetUserProfileUseCase(repo),
+      LogoutUseCase(repo),
+      DeleteAccountUseCase(repo),
+    );
+
+    await cubit.deleteAccount();
+
+    expect(repo.deleteCalled, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add `DELETE /users/me` endpoint for removing the current user
- support account deletion in `AuthRepository` and its implementation
- expose `DeleteAccountUseCase`
- allow `ProfileCubit` to delete accounts and use it from profile screen
- add frontend tests for the new use case and cubit
- test backend deletion behaviour

## Testing
- `pytest backend/tests -q`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a129cbbc83249fed33d2777d69db