### PR TITLE
Fix profile tab error

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ This script ensures `OPENROUTER_API_KEY` and the Spotify credentials are defined
 ## Usage
 
 
-Start the backend and then run the Flutter app. By default the client expects the API to be available at `http://localhost:8000/api/v1/`.
+Start the backend and then run the Flutter app. By default the client expects the
+API to be available at `http://localhost:8000/api/v1/`. When running on an Android
+emulator the app automatically switches to `http://10.0.2.2:8000/api/v1/` so the
+backend can still be reached from the virtual device.
 
 ### App Usage
 

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -1,8 +1,11 @@
+import 'dart:io' show Platform;
+
 import 'package:dear_flutter/core/api/auth_interceptor.dart';
 import 'package:dear_flutter/data/datasources/local/app_database.dart';
 import 'package:dear_flutter/data/datasources/local/chat_message_dao.dart';
 import 'package:dear_flutter/data/datasources/local/journal_dao.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -11,9 +14,15 @@ abstract class RegisterModule {
   // --- NETWORK ---
   @lazySingleton
   Dio dio(AuthInterceptor authInterceptor) {
+    final baseUrl = kIsWeb
+        ? 'http://localhost:8000/api/v1/'
+        : Platform.isAndroid
+            ? 'http://10.0.2.2:8000/api/v1/'
+            : 'http://localhost:8000/api/v1/';
+
     final dio = Dio(
       BaseOptions(
-        baseUrl: 'http://10.0.2.2:8000/api/v1/', // Untuk emulator
+        baseUrl: baseUrl,
         connectTimeout: const Duration(seconds: 30),
         receiveTimeout: const Duration(seconds: 60),
       ),


### PR DESCRIPTION
## Summary
- configure `Dio` base URL dynamically
- document automatic base URL switch in README

## Testing
- `flutter test` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6860a824d3788324928a677f972a638f