### PR TITLE
Fix profile API URL

### DIFF
--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -14,16 +14,12 @@ abstract class RegisterModule {
   // --- NETWORK ---
 @lazySingleton
 Dio dio(AuthInterceptor authInterceptor) {
-  // Ganti IP ini dengan IP lokal komputer Anda
-  const localIp = '10.0.2.2'; // <- Sesuaikan dengan IP lokal Anda
   const port = 8000;
 
-  // Buat baseUrl berdasarkan platform
-  final baseUrl = kIsWeb
-      ? 'http://$localIp:$port/api/v1/'
-      : Platform.isAndroid
-          ? 'http://$localIp:$port/api/v1/' // Perangkat Android (fisik atau emulator AVD)
-          : 'http://$localIp:$port/api/v1/'; // iOS atau desktop
+  // Use Android loopback when running on an emulator, otherwise default to
+  // localhost so the backend can be reached from web, iOS or desktop.
+  final host = Platform.isAndroid ? '10.0.2.2' : 'localhost';
+  final baseUrl = 'http://$host:$port/api/v1/';
 
   final dio = Dio(
     BaseOptions(


### PR DESCRIPTION
## Summary
- adjust base URL resolution for Dio so non-Android builds use localhost

## Testing
- `pytest -q backend/tests/test_user_api.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6860d3d77bac8324a06df615c92e4123