### PR TITLE
Implement home feed feature

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -22,17 +22,21 @@ import '../../data/datasources/remote/auth_api_service.dart' as _i228;
 import '../../data/datasources/remote/chat_api_service.dart' as _i489;
 import '../../data/datasources/remote/journal_api_service.dart' as _i1020;
 import '../../data/datasources/remote/user_api_service.dart' as _i637;
+import '../../data/datasources/remote/home_api_service.dart' as _i2000;
 import '../../data/repositories/auth_repository_impl.dart' as _i895;
 import '../../data/repositories/chat_repository_impl.dart' as _i838;
 import '../../data/repositories/journal_repository_impl.dart' as _i625;
+import '../../data/repositories/home_repository_impl.dart' as _i2001;
 import '../../domain/repositories/auth_repository.dart' as _i1073;
 import '../../domain/repositories/chat_repository.dart' as _i1072;
 import '../../domain/repositories/journal_repository.dart' as _i847;
+import '../../domain/repositories/home_repository.dart' as _i2002;
 import '../../domain/usecases/delete_account_usecase.dart' as _i874;
 import '../../domain/usecases/get_auth_status_usecase.dart' as _i126;
 import '../../domain/usecases/get_chat_history_usecase.dart' as _i992;
 import '../../domain/usecases/get_journals_usecase.dart' as _i738;
 import '../../domain/usecases/get_user_profile_usecase.dart' as _i629;
+import '../../domain/usecases/get_home_feed_usecase.dart' as _i2003;
 import '../../domain/usecases/login_usecase.dart' as _i253;
 import '../../domain/usecases/logout_usecase.dart' as _i981;
 import '../../domain/usecases/register_usecase.dart' as _i35;
@@ -43,6 +47,7 @@ import '../../presentation/auth/cubit/login_cubit.dart' as _i774;
 import '../../presentation/auth/cubit/register_cubit.dart' as _i887;
 import '../../presentation/chat/cubit/chat_cubit.dart' as _i207;
 import '../../presentation/home/cubit/home_cubit.dart' as _i288;
+import '../../presentation/home/cubit/home_feed_cubit.dart' as _i2004;
 import '../../presentation/journal/cubit/journal_editor_cubit.dart' as _i826;
 import '../../presentation/profile/cubit/profile_cubit.dart' as _i107;
 import '../api/auth_interceptor.dart' as _i577;
@@ -88,6 +93,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i228.AuthApiService>(
       () => _i228.AuthApiService(gh<_i361.Dio>()),
     );
+    gh.factory<_i2000.HomeApiService>(
+      () => _i2000.HomeApiService(gh<_i361.Dio>()),
+    );
     gh.lazySingleton<_i1072.ChatRepository>(
       () => _i838.ChatRepositoryImpl(
         gh<_i489.ChatApiService>(),
@@ -99,6 +107,9 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i955.SendMessageUseCase>(
       () => _i955.SendMessageUseCase(gh<_i1072.ChatRepository>()),
+    );
+    gh.lazySingleton<_i2002.HomeRepository>(
+      () => _i2001.HomeRepositoryImpl(gh<_i2000.HomeApiService>()),
     );
     gh.lazySingleton<_i847.JournalRepository>(
       () => _i625.JournalRepositoryImpl(
@@ -140,6 +151,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i415.SaveJournalUseCase>(
       () => _i415.SaveJournalUseCase(gh<_i847.JournalRepository>()),
     );
+    gh.factory<_i2003.GetHomeFeedUseCase>(
+      () => _i2003.GetHomeFeedUseCase(gh<_i2002.HomeRepository>()),
+    );
     gh.factory<_i738.GetJournalsUseCase>(
       () => _i738.GetJournalsUseCase(gh<_i847.JournalRepository>()),
     );
@@ -154,6 +168,9 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i738.GetJournalsUseCase>(),
         gh<_i873.SyncJournalsUseCase>(),
       ),
+    );
+    gh.factory<_i2004.HomeFeedCubit>(
+      () => _i2004.HomeFeedCubit(gh<_i2003.GetHomeFeedUseCase>()),
     );
     gh.factory<_i774.LoginCubit>(
       () => _i774.LoginCubit(gh<_i253.LoginUseCase>()),

--- a/lib/data/datasources/remote/home_api_service.dart
+++ b/lib/data/datasources/remote/home_api_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+
+@injectable
+class HomeApiService {
+  final Dio _dio;
+  HomeApiService(this._dio);
+
+  Future<List<HomeFeedItem>> getHomeFeed() async {
+    final response = await _dio.get('home-feed');
+    final data = response.data as List<dynamic>;
+    return data
+        .map((item) => HomeFeedItem.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/data/repositories/home_repository_impl.dart
+++ b/lib/data/repositories/home_repository_impl.dart
@@ -1,0 +1,16 @@
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+import 'package:dear_flutter/domain/repositories/home_repository.dart';
+
+@LazySingleton(as: HomeRepository)
+class HomeRepositoryImpl implements HomeRepository {
+  final HomeApiService _apiService;
+
+  HomeRepositoryImpl(this._apiService);
+
+  @override
+  Future<List<HomeFeedItem>> getHomeFeed() {
+    return _apiService.getHomeFeed();
+  }
+}

--- a/lib/domain/entities/home_feed_item.dart
+++ b/lib/domain/entities/home_feed_item.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'article.dart';
+import 'audio_track.dart';
+import 'motivational_quote.dart';
+
+part 'home_feed_item.freezed.dart';
+
+@freezed
+class HomeFeedItem with _$HomeFeedItem {
+  const factory HomeFeedItem.article({required Article data}) = HomeFeedArticle;
+  const factory HomeFeedItem.audio({required AudioTrack data}) = HomeFeedAudio;
+  const factory HomeFeedItem.quote({required MotivationalQuote data}) =
+      HomeFeedQuote;
+
+  factory HomeFeedItem.fromJson(Map<String, dynamic> json) {
+    switch (json['type'] as String) {
+      case 'article':
+        return HomeFeedItem.article(
+            data: Article.fromJson(json['data'] as Map<String, dynamic>));
+      case 'audio':
+        return HomeFeedItem.audio(
+            data: AudioTrack.fromJson(json['data'] as Map<String, dynamic>));
+      case 'quote':
+        return HomeFeedItem.quote(
+            data:
+                MotivationalQuote.fromJson(json['data'] as Map<String, dynamic>));
+      default:
+        throw UnsupportedError('Unknown type: ${json['type']}');
+    }
+  }
+}

--- a/lib/domain/entities/motivational_quote.dart
+++ b/lib/domain/entities/motivational_quote.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'motivational_quote.freezed.dart';
+part 'motivational_quote.g.dart';
+
+@freezed
+class MotivationalQuote with _$MotivationalQuote {
+  const factory MotivationalQuote({
+    required int id,
+    required String text,
+    required String author,
+  }) = _MotivationalQuote;
+
+  factory MotivationalQuote.fromJson(Map<String, dynamic> json) =>
+      _$MotivationalQuoteFromJson(json);
+}

--- a/lib/domain/repositories/home_repository.dart
+++ b/lib/domain/repositories/home_repository.dart
@@ -1,0 +1,5 @@
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+
+abstract class HomeRepository {
+  Future<List<HomeFeedItem>> getHomeFeed();
+}

--- a/lib/domain/usecases/get_home_feed_usecase.dart
+++ b/lib/domain/usecases/get_home_feed_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+import 'package:dear_flutter/domain/repositories/home_repository.dart';
+
+@injectable
+class GetHomeFeedUseCase {
+  final HomeRepository _repository;
+  GetHomeFeedUseCase(this._repository);
+
+  Future<List<HomeFeedItem>> call() => _repository.getHomeFeed();
+}

--- a/lib/presentation/home/cubit/home_feed_cubit.dart
+++ b/lib/presentation/home/cubit/home_feed_cubit.dart
@@ -1,0 +1,26 @@
+import 'package:dear_flutter/domain/usecases/get_home_feed_usecase.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_feed_state.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class HomeFeedCubit extends Cubit<HomeFeedState> {
+  final GetHomeFeedUseCase _getHomeFeedUseCase;
+
+  HomeFeedCubit(this._getHomeFeedUseCase) : super(const HomeFeedState()) {
+    fetchHomeFeed();
+  }
+
+  Future<void> fetchHomeFeed() async {
+    emit(state.copyWith(status: HomeFeedStatus.loading));
+    try {
+      final items = await _getHomeFeedUseCase();
+      emit(state.copyWith(status: HomeFeedStatus.success, items: items));
+    } catch (e) {
+      emit(state.copyWith(
+        status: HomeFeedStatus.failure,
+        errorMessage: 'Gagal memuat feed.',
+      ));
+    }
+  }
+}

--- a/lib/presentation/home/cubit/home_feed_state.dart
+++ b/lib/presentation/home/cubit/home_feed_state.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+
+part 'home_feed_state.freezed.dart';
+
+enum HomeFeedStatus { initial, loading, success, failure }
+
+@freezed
+class HomeFeedState with _$HomeFeedState {
+  const factory HomeFeedState({
+    @Default(HomeFeedStatus.initial) HomeFeedStatus status,
+    @Default([]) List<HomeFeedItem> items,
+    String? errorMessage,
+  }) = _HomeFeedState;
+}

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -1,9 +1,8 @@
 // lib/presentation/home/screens/home_screen.dart
 
 import 'package:dear_flutter/core/di/injection.dart';
-import 'package:dear_flutter/presentation/home/cubit/home_cubit.dart';
-import 'package:dear_flutter/presentation/home/cubit/home_state.dart';
-import 'package:dear_flutter/presentation/journal/screens/journal_editor_screen.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_feed_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_feed_state.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -12,51 +11,87 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    const goldenRatio = 1.618;
+
     return BlocProvider(
-      // HomeCubit automatically starts monitoring journals
-      create: (context) => getIt<HomeCubit>(),
+      create: (context) => getIt<HomeFeedCubit>(),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Beranda'),
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) => const JournalEditorScreen(),
-              ),
+        body: BlocBuilder<HomeFeedCubit, HomeFeedState>(
+          builder: (context, state) {
+            if (state.status == HomeFeedStatus.loading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (state.status == HomeFeedStatus.failure) {
+              return Center(
+                child: Text(state.errorMessage ?? 'Terjadi kesalahan'),
+              );
+            }
+            return ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Text(
+                  'Selamat datang!',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 16),
+                ...state.items.map(
+                  (item) => Padding(
+                    padding: const EdgeInsets.only(bottom: 16.0),
+                    child: _HomeFeedCard(
+                      item: item,
+                      height: screenHeight / goldenRatio,
+                    ),
+                  ),
+                ),
+              ],
             );
           },
-          child: const Icon(Icons.add),
         ),
-        body: BlocBuilder<HomeCubit, HomeState>(
-          builder: (context, state) {
-            switch (state.status) {
-              case HomeStatus.initial:
-              case HomeStatus.loading:
-                return const Center(child: CircularProgressIndicator());
+      ),
+    );
+  }
+}
 
-              case HomeStatus.failure:
-                return Center(
-                  child: Text(state.errorMessage ?? 'Terjadi kesalahan'),
-                );
+class _HomeFeedCard extends StatelessWidget {
+  const _HomeFeedCard({required this.item, required this.height});
 
-              case HomeStatus.success:
-                if (state.journals.isEmpty) {
-                  return const Center(child: Text('Belum ada jurnal.'));
-                }
-                return ListView.builder(
-                  itemCount: state.journals.length,
-                  itemBuilder: (context, index) {
-                    final journal = state.journals[index];
-                    return ListTile(
-                      title: Text(journal.title),
-                      subtitle: Text(journal.mood),
-                    );
-                  },
-                );
-            }
-          },
+  final HomeFeedItem item;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: item.when(
+            article: (data) => Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Artikel'),
+                Text(data.title),
+              ],
+            ),
+            audio: (data) => Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Musik'),
+                Text(data.title),
+              ],
+            ),
+            quote: (data) => Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Quote'),
+                Text('"${data.text}" - ${data.author}'),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/test/home_repository_test.dart
+++ b/test/home_repository_test.dart
@@ -1,0 +1,50 @@
+import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
+import 'package:dear_flutter/data/repositories/home_repository_impl.dart';
+import 'package:dear_flutter/domain/entities/article.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    if (options.path == 'home-feed') {
+      handler.resolve(
+        Response(requestOptions: options, data: [
+          {
+            'type': 'article',
+            'data': {'id': 1, 'title': 'a', 'url': 'u'}
+          },
+          {
+            'type': 'audio',
+            'data': {'id': 2, 'title': 't', 'url': 'm'}
+          },
+          {
+            'type': 'quote',
+            'data': {'id': 3, 'text': 'q', 'author': 'au'}
+          },
+        ]),
+      );
+    } else {
+      handler.reject(DioException(requestOptions: options, error: 'unexpected'));
+    }
+  }
+}
+
+void main() {
+  test('HomeRepositoryImpl parses feed items', () async {
+    final dio = Dio();
+    dio.interceptors.add(_FakeInterceptor());
+    final service = HomeApiService(dio);
+    final repo = HomeRepositoryImpl(service);
+
+    final items = await repo.getHomeFeed();
+
+    expect(items.length, 3);
+    expect(items[0], const HomeFeedItem.article(data: Article(id: 1, title: 'a', url: 'u')));
+    expect(items[1], const HomeFeedItem.audio(data: AudioTrack(id: 2, title: 't', url: 'm')));
+    expect(items[2], const HomeFeedItem.quote(data: MotivationalQuote(id: 3, text: 'q', author: 'au')));
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,17 +11,34 @@ import 'package:get_it/get_it.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
-import 'package:dear_flutter/presentation/home/cubit/home_cubit.dart';
-import 'package:dear_flutter/presentation/home/cubit/home_state.dart';
+import 'package:dear_flutter/domain/entities/article.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_feed_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_feed_state.dart';
 
-class _FakeHomeCubit extends Cubit<HomeState> implements HomeCubit {
-  _FakeHomeCubit() : super(const HomeState());
+final _sampleItems = [
+  const HomeFeedItem.article(
+    data: Article(id: 1, title: 'a', url: 'u'),
+  ),
+  const HomeFeedItem.audio(
+    data: AudioTrack(id: 2, title: 't', url: 'm'),
+  ),
+  const HomeFeedItem.quote(
+    data: MotivationalQuote(id: 3, text: 'q', author: 'au'),
+  ),
+];
+
+class _FakeHomeFeedCubit extends Cubit<HomeFeedState> implements HomeFeedCubit {
+  _FakeHomeFeedCubit()
+      : super(const HomeFeedState(
+          status: HomeFeedStatus.success,
+          items: _sampleItems,
+        ));
 
   @override
-  Future<void> syncJournals() async {}
-
-  @override
-  void watchJournals() {}
+  Future<void> fetchHomeFeed() async {}
 }
 
 void main() {
@@ -29,15 +46,18 @@ void main() {
 
   setUp(() {
     getIt.reset();
-    getIt.registerFactory<HomeCubit>(() => _FakeHomeCubit());
+    getIt.registerFactory<HomeFeedCubit>(() => _FakeHomeFeedCubit());
   });
 
   tearDown(getIt.reset);
 
-  testWidgets('HomeScreen renders without error', (WidgetTester tester) async {
+  testWidgets('HomeScreen renders feed cards', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
 
     expect(find.byType(HomeScreen), findsOneWidget);
     expect(find.text('Beranda'), findsOneWidget);
+    expect(find.text('a'), findsOneWidget);
+    expect(find.text('t'), findsOneWidget);
+    expect(find.textContaining('q'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement `HomeApiService` for `/home-feed`
- add entities for motivational quotes and home feed items
- create repository, use case, cubit and state for home feed
- update dependency injection configuration
- revise `HomeScreen` to show greeting and home feed cards
- add tests for home repository and widget rendering

## Testing
- `dart run build_runner build --delete-conflicting-outputs` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860f2fb501c83248a18adb5a3848338