### PR TITLE
Fix missing HomeFeedItem import

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -3,6 +3,7 @@
 import 'package:dear_flutter/core/di/injection.dart';
 import 'package:dear_flutter/presentation/home/cubit/home_feed_cubit.dart';
 import 'package:dear_flutter/presentation/home/cubit/home_feed_state.dart';
+import 'package:dear_flutter/domain/entities/home_feed_item.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 


### PR DESCRIPTION
## Summary
- import `HomeFeedItem` in home screen

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6860f6a73a7c8324ab71f886f065ddc3