### PR TITLE
Fix home feed parse error

### DIFF
--- a/lib/domain/entities/article.dart
+++ b/lib/domain/entities/article.dart
@@ -5,8 +5,8 @@ part 'article.g.dart';
 
 @freezed
 class Article with _$Article {
-    const factory Article({
-        required String id,
+  const factory Article({
+        required int id,
         required String title,
         required String url,
     }) = _Article;

--- a/lib/domain/entities/audio_track.dart
+++ b/lib/domain/entities/audio_track.dart
@@ -6,7 +6,7 @@ part 'audio_track.g.dart';
 @freezed
 class AudioTrack with _$AudioTrack {
   const factory AudioTrack({
-    required String id,
+    required int id,
     required String title,
     required String url,
   }) = _AudioTrack;


### PR DESCRIPTION
## Summary
- fix feed item models to use `int` ID like the backend

## Testing
- `pytest -q backend/tests/test_home_api.py::test_home_feed_structure_and_ordering -vv` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6860f99c8bc48324a038c91f71f53c63