### PR TITLE
Ensure int ID fields in entities

### DIFF
--- a/lib/domain/entities/article.dart
+++ b/lib/domain/entities/article.dart
@@ -6,10 +6,10 @@ part 'article.g.dart';
 @freezed
 class Article with _$Article {
   const factory Article({
-        required int id,
-        required String title,
-        required String url,
-    }) = _Article;
+    required int id,
+    required String title,
+    required String url,
+  }) = _Article;
 
     factory Article.fromJson(Map<String, dynamic> json) => _$ArticleFromJson(json);
 }


### PR DESCRIPTION
## Summary
- confirm `Article` and `AudioTrack` entities use `int` IDs
- minor formatting update for `article.dart`

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs` *(fails: flutter not found)*
- `pytest backend/tests` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6860fddb151c8324a042a846632f5d7d