### PR TITLE
Add detail screens with GoRouter navigation

### DIFF
--- a/lib/core/navigation/app_router.dart
+++ b/lib/core/navigation/app_router.dart
@@ -6,6 +6,12 @@ import 'package:dear_flutter/presentation/chat/screens/chat_screen.dart';
 import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
 import 'package:dear_flutter/presentation/main/main_screen.dart';
 import 'package:dear_flutter/presentation/profile/screens/profile_screen.dart'; // Sudah ditambahkan
+import 'package:dear_flutter/presentation/home/screens/article_detail_screen.dart';
+import 'package:dear_flutter/presentation/home/screens/audio_player_screen.dart';
+import 'package:dear_flutter/presentation/home/screens/quote_detail_screen.dart';
+import 'package:dear_flutter/domain/entities/article.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -53,6 +59,23 @@ final GoRouter router = GoRouter(
           ],
         ),
       ],
+    ),
+
+    // Detail routes di luar shell
+    GoRoute(
+      path: '/article',
+      builder: (context, state) =>
+          ArticleDetailScreen(article: state.extra as Article),
+    ),
+    GoRoute(
+      path: '/audio',
+      builder: (context, state) =>
+          AudioPlayerScreen(track: state.extra as AudioTrack),
+    ),
+    GoRoute(
+      path: '/quote',
+      builder: (context, state) =>
+          QuoteDetailScreen(quote: state.extra as MotivationalQuote),
     ),
 
     // Route luar shell (autentikasi)

--- a/lib/presentation/home/screens/article_detail_screen.dart
+++ b/lib/presentation/home/screens/article_detail_screen.dart
@@ -1,0 +1,31 @@
+import 'package:dear_flutter/domain/entities/article.dart';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class ArticleDetailScreen extends StatefulWidget {
+  const ArticleDetailScreen({super.key, required this.article});
+
+  final Article article;
+
+  @override
+  State<ArticleDetailScreen> createState() => _ArticleDetailScreenState();
+}
+
+class _ArticleDetailScreenState extends State<ArticleDetailScreen> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..loadRequest(Uri.parse(widget.article.url));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.article.title)),
+      body: WebViewWidget(controller: _controller),
+    );
+  }
+}

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -4,15 +4,13 @@ import 'package:dear_flutter/core/di/injection.dart';
 import 'package:dear_flutter/presentation/home/cubit/home_feed_cubit.dart';
 import 'package:dear_flutter/presentation/home/cubit/home_feed_state.dart';
 import 'package:dear_flutter/domain/entities/home_feed_item.dart';
-import 'package:dear_flutter/domain/entities/audio_track.dart';
-import 'package:dear_flutter/domain/entities/motivational_quote.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'package:share_plus/share_plus.dart';
+import 'package:go_router/go_router.dart';
 
+import 'article_detail_screen.dart';
 import 'audio_player_screen.dart';
+import 'quote_detail_screen.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -94,7 +92,7 @@ class _HomeFeedCard extends StatelessWidget {
             leading: const Icon(Icons.format_quote),
             title: Text('"${data.text}"'),
             subtitle: Text(data.author),
-            trailing: const Icon(Icons.more_vert),
+            trailing: const Icon(Icons.chevron_right),
           ),
         ),
       ),
@@ -102,61 +100,17 @@ class _HomeFeedCard extends StatelessWidget {
   }
 }
 
-Future<void> _handleItemTap(BuildContext context, HomeFeedItem item) async {
-  await item.when(
-    article: (data) async {
-      final uri = Uri.parse(data.url);
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Tidak dapat membuka tautan')),
-        );
-      }
+void _handleItemTap(BuildContext context, HomeFeedItem item) {
+  item.when(
+    article: (data) {
+      context.push('/article', extra: data);
     },
     audio: (data) {
-      Navigator.of(context).push(
-        MaterialPageRoute(builder: (_) => AudioPlayerScreen(track: data)),
-      );
+      context.push('/audio', extra: data);
     },
     quote: (data) {
-      _showQuoteActions(context, data);
+      context.push('/quote', extra: data);
     },
   );
 }
 
-void _showQuoteActions(BuildContext context, MotivationalQuote quote) {
-  showModalBottomSheet(
-    context: context,
-    builder: (context) {
-      return SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.copy),
-              title: const Text('Copy'),
-              onTap: () {
-                Clipboard.setData(
-                  ClipboardData(text: '"${quote.text}" - ${quote.author}'),
-                );
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Disalin ke clipboard')),
-                );
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.share),
-              title: const Text('Share'),
-              onTap: () {
-                Share.share('"${quote.text}" - ${quote.author}');
-                Navigator.pop(context);
-              },
-            ),
-          ],
-        ),
-      );
-    },
-  );
-}

--- a/lib/presentation/home/screens/quote_detail_screen.dart
+++ b/lib/presentation/home/screens/quote_detail_screen.dart
@@ -1,0 +1,81 @@
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+
+class QuoteDetailScreen extends StatelessWidget {
+  const QuoteDetailScreen({super.key, required this.quote});
+
+  final MotivationalQuote quote;
+
+  void _showActions(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.copy),
+                title: const Text('Copy'),
+                onTap: () {
+                  Clipboard.setData(
+                    ClipboardData(text: '"${quote.text}" - ${quote.author}'),
+                  );
+                  Navigator.pop(context);
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Disalin ke clipboard')),
+                  );
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.share),
+                title: const Text('Share'),
+                onTap: () {
+                  Share.share('"${quote.text}" - ${quote.author}');
+                  Navigator.pop(context);
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Quote'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.more_vert),
+            onPressed: () => _showActions(context),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '"${quote.text}"',
+                style: Theme.of(context).textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                quote.author,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   json_annotation: ^4.8.1                # Untuk serialisasi model
   url_launcher: ^6.2.6                  # Membuka tautan eksternal
   share_plus: ^7.2.1                    # Berbagi konten
+  webview_flutter: ^4.4.1              # Menampilkan halaman web dalam aplikasi
   audioplayers: ^5.1.0                  # Pemutar audio sederhana
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add ArticleDetailScreen and QuoteDetailScreen
- enable webview_flutter
- connect home feed card taps to GoRouter
- add routes for article, audio and quote details

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613038c8d0832495e1d82cb7e6b206