### PR TITLE
Add navigation widget tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dev_dependencies:
   injectable_generator: ^2.4.1           # Codegen untuk dependency injection
   json_serializable: ^6.7.1              # Codegen untuk JSON
   drift_dev: ^2.14.0                     # Codegen untuk ORM Drift
+  mocktail: ^1.0.1                       # Untuk mocking di unit test
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- verify home feed navigation in widget tests
- use mocktail for mocking NavigatorObserver

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614eedd25483249a1a53bad7576dc6