### PR TITLE
Add /quotes/latest endpoint

### DIFF
--- a/backend/app/api/v1/quote.py
+++ b/backend/app/api/v1/quote.py
@@ -8,3 +8,8 @@ router = APIRouter()
 @router.get("/", response_model=list[schemas.MotivationalQuote])
 def get_quotes(db: Session = Depends(get_db)):
     return crud.motivational_quote.get_multi(db)
+
+
+@router.get("/latest", response_model=schemas.MotivationalQuote | None)
+def get_latest_quote(db: Session = Depends(get_db)):
+    return crud.motivational_quote.get_latest(db)

--- a/backend/app/crud/crud_motivational_quote.py
+++ b/backend/app/crud/crud_motivational_quote.py
@@ -1,9 +1,11 @@
 from sqlalchemy.orm import Session
+from sqlalchemy import desc
 from .base import CRUDBase
 from app.models.motivational_quote import MotivationalQuote
 from app.schemas.motivational_quote import MotivationalQuoteCreate, MotivationalQuoteUpdate
 
 class CRUDMotivationalQuote(CRUDBase[MotivationalQuote, MotivationalQuoteCreate, MotivationalQuoteUpdate]):
-    pass
+    def get_latest(self, db: Session) -> MotivationalQuote | None:
+        return db.query(self.model).order_by(desc(self.model.id)).first()
 
 motivational_quote = CRUDMotivationalQuote(MotivationalQuote)

--- a/backend/tests/test_list_endpoints.py
+++ b/backend/tests/test_list_endpoints.py
@@ -79,3 +79,24 @@ def test_quotes_endpoint_returns_items(client):
     data = resp.json()
     assert isinstance(data, list)
     assert len(data) == 2
+
+
+def test_quotes_latest_endpoint_returns_latest_item(client):
+    client_app, session_local = client
+    db = session_local()
+    try:
+        crud.motivational_quote.create(
+            db,
+            obj_in=schemas.MotivationalQuoteCreate(text="old", author="anon"),
+        )
+        crud.motivational_quote.create(
+            db,
+            obj_in=schemas.MotivationalQuoteCreate(text="new", author="anon"),
+        )
+    finally:
+        db.close()
+
+    resp = client_app.get("/api/v1/quotes/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["text"] == "new"


### PR DESCRIPTION
## Summary
- add `get_latest` to `CRUDMotivationalQuote`
- expose `/latest` endpoint for quotes
- test that `/api/v1/quotes/latest` returns newest quote

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627a0dfc3c8324920f103ce9dd4626