### PR TITLE
Add quote notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Run the application on an attached device or emulator:
 flutter run
 ```
 
+## Notifications
+
+Local notifications are powered by `flutter_local_notifications`. The
+`NotificationService` is initialized in `main.dart` and automatically polls the
+`/quotes/latest` endpoint every 15 minutes. When a new quote is found a
+notification is shown and tapping it opens the quote detail screen.
+
+On Android the default app icon is used for the notification. No additional
+configuration is required other than granting notification permissions on first
+launch.
+
 ## Backend Setup
 
 1. Create and activate a Python virtual environment:

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -4,6 +4,9 @@ import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 
 import 'injection.config.dart'; // File ini akan dibuat oleh generator
+import '../../services/notification_service.dart';
+import '../../services/quote_update_service.dart';
+import '../../data/datasources/remote/home_api_service.dart';
 
 final getIt = GetIt.instance;
 
@@ -12,4 +15,10 @@ final getIt = GetIt.instance;
   preferRelativeImports: true, // default
   asExtension: true, // default
 )
-Future<GetIt> configureDependencies() => getIt.init();
+Future<GetIt> configureDependencies() async {
+  await getIt.init();
+  getIt.registerLazySingleton<NotificationService>(() => NotificationService());
+  getIt.registerLazySingleton<QuoteUpdateService>(
+      () => QuoteUpdateService(getIt<HomeApiService>(), getIt<NotificationService>()));
+  return getIt;
+}

--- a/lib/data/datasources/remote/home_api_service.dart
+++ b/lib/data/datasources/remote/home_api_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
 
 @injectable
 class HomeApiService {
@@ -13,5 +14,11 @@ class HomeApiService {
     return data
         .map((item) => HomeFeedItem.fromJson(item as Map<String, dynamic>))
         .toList();
+  }
+
+  Future<MotivationalQuote> getLatestQuote() async {
+    final response = await _dio.get('quotes/latest');
+    return MotivationalQuote.fromJson(
+        response.data as Map<String, dynamic>);
   }
 }

--- a/lib/data/repositories/home_repository_impl.dart
+++ b/lib/data/repositories/home_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:injectable/injectable.dart';
 import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
 import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
 import 'package:dear_flutter/domain/repositories/home_repository.dart';
 
 @LazySingleton(as: HomeRepository)
@@ -12,5 +13,10 @@ class HomeRepositoryImpl implements HomeRepository {
   @override
   Future<List<HomeFeedItem>> getHomeFeed() {
     return _apiService.getHomeFeed();
+  }
+
+  @override
+  Future<MotivationalQuote> getLatestQuote() {
+    return _apiService.getLatestQuote();
   }
 }

--- a/lib/domain/repositories/home_repository.dart
+++ b/lib/domain/repositories/home_repository.dart
@@ -1,5 +1,7 @@
 import 'package:dear_flutter/domain/entities/home_feed_item.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
 
 abstract class HomeRepository {
   Future<List<HomeFeedItem>> getHomeFeed();
+  Future<MotivationalQuote> getLatestQuote();
 }

--- a/lib/domain/usecases/get_latest_quote_usecase.dart
+++ b/lib/domain/usecases/get_latest_quote_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/repositories/home_repository.dart';
+
+@injectable
+class GetLatestQuoteUseCase {
+  final HomeRepository _repository;
+  GetLatestQuoteUseCase(this._repository);
+
+  Future<MotivationalQuote> call() => _repository.getLatestQuote();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:dear_flutter/core/di/injection.dart';
 import 'package:dear_flutter/core/navigation/app_router.dart'; // Router konfigurasi
+import 'package:dear_flutter/services/notification_service.dart';
+import 'package:dear_flutter/services/quote_update_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Inisialisasi dependency injection (getIt, dll.)
   await configureDependencies();
+  await getIt<NotificationService>().init();
+  getIt<QuoteUpdateService>().start();
 
   runApp(const MyApp());
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:dear_flutter/core/navigation/app_router.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:injectable/injectable.dart';
+
+@LazySingleton()
+class NotificationService {
+  final FlutterLocalNotificationsPlugin _plugin = FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const iosInit = DarwinInitializationSettings();
+    const settings = InitializationSettings(android: androidInit, iOS: iosInit);
+
+    await _plugin.initialize(
+      settings,
+      onDidReceiveNotificationResponse: (details) {
+        final payload = details.payload;
+        if (payload == null) return;
+        final data = jsonDecode(payload) as Map<String, dynamic>;
+        final quote = MotivationalQuote.fromJson(data);
+        router.push('/quote', extra: quote);
+      },
+    );
+  }
+
+  Future<void> showQuoteNotification(MotivationalQuote quote) async {
+    const androidDetails = AndroidNotificationDetails(
+      'quote_channel',
+      'Quotes',
+      channelDescription: 'Motivational quote notifications',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+    const notificationDetails = NotificationDetails(android: androidDetails);
+
+    await _plugin.show(
+      quote.id,
+      'Motivation',
+      '"${quote.text}" - ${quote.author}',
+      notificationDetails,
+      payload: jsonEncode(quote.toJson()),
+    );
+  }
+}

--- a/lib/services/quote_update_service.dart
+++ b/lib/services/quote_update_service.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:injectable/injectable.dart';
+
+import 'notification_service.dart';
+
+@LazySingleton()
+class QuoteUpdateService {
+  final HomeApiService _apiService;
+  final NotificationService _notificationService;
+
+  Timer? _timer;
+  MotivationalQuote? _lastQuote;
+
+  QuoteUpdateService(this._apiService, this._notificationService);
+
+  void start() {
+    _timer?.cancel();
+    _fetch();
+    _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
+  }
+
+  Future<void> _fetch() async {
+    try {
+      final quote = await _apiService.getLatestQuote();
+      if (_lastQuote == null || quote.id != _lastQuote!.id) {
+        _lastQuote = quote;
+        await _notificationService.showQuoteNotification(quote);
+      }
+    } catch (_) {
+      // Ignore errors silently
+    }
+  }
+
+  void dispose() {
+    _timer?.cancel();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   share_plus: ^7.2.1                    # Berbagi konten
   webview_flutter: ^4.4.1              # Menampilkan halaman web dalam aplikasi
   audioplayers: ^5.1.0                  # Pemutar audio sederhana
+  flutter_local_notifications: ^16.1.0  # Notifikasi lokal
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add flutter_local_notifications dependency
- create NotificationService and QuoteUpdateService
- fetch latest quote via new API method
- show quote notification and open detail screen
- start notification services from main
- document notifications setup

## Testing
- `pip install -r backend/requirements.txt`
- `pip install pytest`
- `pytest backend/tests` *(fails: ValidationError for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_68627d0c1f4483248fb6e027bb1edd7f