### PR TITLE
docs: explain android desugaring fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ Run the application on an attached device or emulator:
 flutter run
 ```
 
+### Android build issues
+
+If the build fails with an error such as:
+
+```
+Dependency ':flutter_local_notifications' requires desugar_jdk_libs version to be 2.1.4 or above
+```
+
+Edit `android/app/build.gradle` and ensure desugaring is enabled:
+
+```gradle
+android {
+    compileOptions {
+        coreLibraryDesugaringEnabled true
+    }
+}
+
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+}
+```
+Then run `flutter clean` followed by `flutter run`.
+
 ## Notifications
 
 Local notifications are powered by `flutter_local_notifications`. The


### PR DESCRIPTION
## Summary
- document how to resolve the desugar library error when building Android

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629ef893cc8324ba7500b741660e2c