### PR TITLE
Fix GetIt duplicate registration

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -4,9 +4,6 @@ import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 
 import 'injection.config.dart'; // File ini akan dibuat oleh generator
-import '../../services/notification_service.dart';
-import '../../services/quote_update_service.dart';
-import '../../data/datasources/remote/home_api_service.dart';
 
 final getIt = GetIt.instance;
 
@@ -17,8 +14,5 @@ final getIt = GetIt.instance;
 )
 Future<GetIt> configureDependencies() async {
   await getIt.init();
-  getIt.registerLazySingleton<NotificationService>(() => NotificationService());
-  getIt.registerLazySingleton<QuoteUpdateService>(
-      () => QuoteUpdateService(getIt<HomeApiService>(), getIt<NotificationService>()));
   return getIt;
 }


### PR DESCRIPTION
## Summary
- remove manual registration of `NotificationService` and `QuoteUpdateService` from `configureDependencies` because `injectable` already provides them

## Testing
- `dart format lib/core/di/injection.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6862a503a71c8324b65fd68b1c93a673