### PR TITLE
Fix home API endpoint paths

### DIFF
--- a/lib/data/datasources/remote/home_api_service.dart
+++ b/lib/data/datasources/remote/home_api_service.dart
@@ -9,7 +9,7 @@ class HomeApiService {
   HomeApiService(this._dio);
 
   Future<List<HomeFeedItem>> getHomeFeed() async {
-    final response = await _dio.get('home-feed');
+    final response = await _dio.get('home-feed/');
     final data = response.data as List<dynamic>;
     return data
         .map((item) => HomeFeedItem.fromJson(item as Map<String, dynamic>))
@@ -17,7 +17,7 @@ class HomeApiService {
   }
 
   Future<MotivationalQuote> getLatestQuote() async {
-    final response = await _dio.get('quotes/latest');
+    final response = await _dio.get('quotes/latest/');
     return MotivationalQuote.fromJson(
         response.data as Map<String, dynamic>);
   }


### PR DESCRIPTION
## Summary
- ensure `home-feed` and `quotes/latest` requests include trailing slashes

## Testing
- `dart format lib/data/datasources/remote/home_api_service.dart` *(fails: dart not installed)*
- `dart analyze lib/data/datasources/remote/home_api_service.dart` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862a9d8d0bc8324bf8cfd968503713b