### PR TITLE
Fix home feed path in test

### DIFF
--- a/test/home_repository_test.dart
+++ b/test/home_repository_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 class _FakeInterceptor extends Interceptor {
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    if (options.path == 'home-feed') {
+    if (options.path == 'home-feed/') {
       handler.resolve(
         Response(requestOptions: options, data: [
           {


### PR DESCRIPTION
## Summary
- update mock interceptor to match trailing slash

## Issues
- n/a

## Affected Files
- `test/home_repository_test.dart`

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ade2da908324b61e7b10cd49c76e