### PR TITLE
Fix Alembic migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ alembic revision --autogenerate -m "<description>"
 # apply migrations
 alembic upgrade head
 ```
+Ensure the `DATABASE_URL` environment variable is set before running
+`alembic upgrade head`; the migration script reads this value to connect
+to your database.
 ### Loading Sample Data
 
 After applying migrations you can populate some example articles, audio tracks and motivational quotes. Run the seeding script:

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -84,6 +84,7 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
+# The DATABASE_URL environment variable is read by migrations/env.py
 sqlalchemy.url = driver://user:pass@localhost/dbname
 
 

--- a/backend/app/alembic.ini
+++ b/backend/app/alembic.ini
@@ -84,6 +84,7 @@ path_separator = os
 # database URL.  This is consumed by the user-maintained env.py script only.
 # other means of configuring database URLs may be customized within the env.py
 # file.
+# The DATABASE_URL environment variable is read by migrations/env.py
 sqlalchemy.url = driver://user:pass@localhost/dbname
 
 


### PR DESCRIPTION
## Summary
- document that Alembic uses `DATABASE_URL`
- clarify configuration in both `alembic.ini` files

## Testing
- `ruff check backend/migrations/env.py`
- `black backend/migrations/env.py`
- `pytest -q` *(fails: DATABASE_URL and other env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862bf8485108324b6b4f0816c975aa9