### PR TITLE
Implement YouTube audio streaming

### DIFF
--- a/backend/app/db/seed.py
+++ b/backend/app/db/seed.py
@@ -12,11 +12,11 @@ ARTICLES = [
 AUDIO_TRACKS = [
     {
         "title": "Relaxing Piano",
-        "url": "https://open.spotify.com/track/6xGruZOHLs39ZbVccQTuPZ",
+        "youtube_id": "6xGruZOHLs39ZbVccQTuPZ",
     },
     {
         "title": "Nature Sounds",
-        "url": "https://open.spotify.com/track/1DWoCzCRlaKY9cRkZZEwQp",
+        "youtube_id": "1DWoCzCRlaKY9cRkZZEwQp",
     },
 ]
 
@@ -36,7 +36,9 @@ def seed() -> None:
             crud.audio_track.create(db, obj_in=schemas.AudioTrackCreate(**data))
 
         for data in QUOTES:
-            crud.motivational_quote.create(db, obj_in=schemas.MotivationalQuoteCreate(**data))
+            crud.motivational_quote.create(
+                db, obj_in=schemas.MotivationalQuoteCreate(**data)
+            )
     finally:
         db.close()
 

--- a/backend/app/models/audio.py
+++ b/backend/app/models/audio.py
@@ -1,7 +1,8 @@
 from sqlalchemy import Column, Integer, String
 from app.db.base_class import Base
 
+
 class AudioTrack(Base):
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String)
-    url = Column(String)
+    youtube_id = Column(String)

--- a/backend/app/schemas/audio.py
+++ b/backend/app/schemas/audio.py
@@ -1,14 +1,18 @@
 from pydantic import BaseModel, ConfigDict
 
+
 class AudioTrackBase(BaseModel):
     title: str
-    url: str
+    youtube_id: str
+
 
 class AudioTrackCreate(AudioTrackBase):
     pass
 
+
 class AudioTrackUpdate(AudioTrackBase):
     pass
+
 
 class AudioTrack(AudioTrackBase):
     id: int

--- a/backend/tests/test_home_api.py
+++ b/backend/tests/test_home_api.py
@@ -4,8 +4,12 @@ from app import crud, schemas
 def _create_sample_data(db):
     crud.article.create(db, obj_in=schemas.ArticleCreate(title="a1", url="u1"))
     crud.article.create(db, obj_in=schemas.ArticleCreate(title="a2", url="u2"))
-    crud.audio_track.create(db, obj_in=schemas.AudioTrackCreate(title="t1", url="au1"))
-    crud.motivational_quote.create(db, obj_in=schemas.MotivationalQuoteCreate(text="q1", author="au"))
+    crud.audio_track.create(
+        db, obj_in=schemas.AudioTrackCreate(title="t1", youtube_id="au1")
+    )
+    crud.motivational_quote.create(
+        db, obj_in=schemas.MotivationalQuoteCreate(text="q1", author="au")
+    )
 
 
 def test_home_feed_structure_and_ordering(client):

--- a/backend/tests/test_list_endpoints.py
+++ b/backend/tests/test_list_endpoints.py
@@ -39,7 +39,9 @@ def test_audio_endpoint_returns_items(client):
     client_app, session_local = client
     db = session_local()
     try:
-        crud.audio_track.create(db, obj_in=schemas.AudioTrackCreate(title="a1", url="u1"))
+        crud.audio_track.create(
+            db, obj_in=schemas.AudioTrackCreate(title="a1", youtube_id="u1")
+        )
     finally:
         db.close()
 

--- a/lib/domain/entities/audio_track.dart
+++ b/lib/domain/entities/audio_track.dart
@@ -8,7 +8,7 @@ class AudioTrack with _$AudioTrack {
   const factory AudioTrack({
     required int id,
     required String title,
-    required String url,
+    @JsonKey(name: 'youtube_id') required String youtubeId,
   }) = _AudioTrack;
 
   factory AudioTrack.fromJson(Map<String, dynamic> json) => _$AudioTrackFromJson(json);

--- a/lib/presentation/home/screens/audio_player_screen.dart
+++ b/lib/presentation/home/screens/audio_player_screen.dart
@@ -1,6 +1,7 @@
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/services/youtube_audio_service.dart';
 
 class AudioPlayerScreen extends StatefulWidget {
   const AudioPlayerScreen({super.key, required this.track});
@@ -13,12 +14,15 @@ class AudioPlayerScreen extends StatefulWidget {
 
 class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
   late final AudioPlayer _player;
+  late final YoutubeAudioService _youtube;
+  String? _resolvedUrl;
   bool _isPlaying = false;
 
   @override
   void initState() {
     super.initState();
     _player = AudioPlayer();
+    _youtube = YoutubeAudioService();
     _player.onPlayerStateChanged.listen((state) {
       setState(() {
         _isPlaying = state == PlayerState.playing;
@@ -29,6 +33,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
   @override
   void dispose() {
     _player.dispose();
+    _youtube.close();
     super.dispose();
   }
 
@@ -36,7 +41,10 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
     if (_isPlaying) {
       await _player.pause();
     } else {
-      await _player.play(UrlSource(widget.track.url));
+      _resolvedUrl ??= await _youtube.getAudioUrl(widget.track.youtubeId);
+      if (_resolvedUrl != null) {
+        await _player.play(UrlSource(_resolvedUrl!));
+      }
     }
   }
 

--- a/lib/services/youtube_audio_service.dart
+++ b/lib/services/youtube_audio_service.dart
@@ -1,0 +1,36 @@
+import 'package:injectable/injectable.dart';
+import 'package:youtube_explode_dart/youtube_explode_dart.dart';
+
+/// Service to obtain playable audio streams from YouTube videos.
+@LazySingleton()
+class AudioInfo {
+  final int bitrate;
+  final Uri url;
+  AudioInfo(this.bitrate, this.url);
+}
+
+typedef _AudioFetcher = Future<List<AudioInfo>> Function(String id);
+
+class YoutubeAudioService {
+  YoutubeAudioService({YoutubeExplode? client, _AudioFetcher? fetcher})
+      : _yt = client ?? YoutubeExplode(),
+        _fetcher = fetcher;
+  final YoutubeExplode _yt;
+  final _AudioFetcher? _fetcher;
+
+  /// Returns the direct audio stream URL for the given YouTube [videoIdOrUrl].
+  Future<String> getAudioUrl(String videoIdOrUrl) async {
+    final infos = _fetcher != null
+        ? await _fetcher!(videoIdOrUrl)
+        : (await _yt.videos.streamsClient
+                .getManifest(videoIdOrUrl))
+            .audioOnly
+            .map((e) => AudioInfo(e.bitrate.kiloBitsPerSecond.toInt(), e.url))
+            .toList();
+    infos.sort((a, b) => a.bitrate.compareTo(b.bitrate));
+    return infos.last.url.toString();
+  }
+
+  /// Dispose the underlying [YoutubeExplode] client.
+  void close() => _yt.close();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   webview_flutter: ^4.4.1              # Menampilkan halaman web dalam aplikasi
   audioplayers: ^5.1.0                  # Pemutar audio sederhana
   flutter_local_notifications: ^19.3.0
+  youtube_explode_dart: ^1.12.4
   
 dev_dependencies:
   flutter_test:

--- a/test/home_repository_test.dart
+++ b/test/home_repository_test.dart
@@ -19,7 +19,7 @@ class _FakeInterceptor extends Interceptor {
           },
           {
             'type': 'audio',
-            'data': {'id': 2, 'title': 't', 'url': 'm'}
+            'data': {'id': 2, 'title': 't', 'youtube_id': 'm'}
           },
           {
             'type': 'quote',
@@ -44,7 +44,8 @@ void main() {
 
     expect(items.length, 3);
     expect(items[0], const HomeFeedItem.article(data: Article(id: 1, title: 'a', url: 'u')));
-    expect(items[1], const HomeFeedItem.audio(data: AudioTrack(id: 2, title: 't', url: 'm')));
+    expect(
+        items[1], const HomeFeedItem.audio(data: AudioTrack(id: 2, title: 't', youtubeId: 'm')));
     expect(items[2], const HomeFeedItem.quote(data: MotivationalQuote(id: 3, text: 'q', author: 'au')));
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -27,7 +27,7 @@ final _sampleItems = [
     data: Article(id: 1, title: 'a', url: 'u'),
   ),
   const HomeFeedItem.audio(
-    data: AudioTrack(id: 2, title: 't', url: 'm'),
+    data: AudioTrack(id: 2, title: 't', youtubeId: 'm'),
   ),
   const HomeFeedItem.quote(
     data: MotivationalQuote(id: 3, text: 'q', author: 'au'),

--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -1,0 +1,14 @@
+import 'package:dear_flutter/services/youtube_audio_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('returns highest bitrate url', () async {
+    final service = YoutubeAudioService(fetcher: (id) async => [
+      AudioInfo(128, Uri.parse('u1')),
+      AudioInfo(256, Uri.parse('u2')),
+    ]);
+
+    final url = await service.getAudioUrl('abc');
+    expect(url, 'u2');
+  });
+}


### PR DESCRIPTION
## Summary
- add `youtube_explode_dart` dependency
- create `YoutubeAudioService` to resolve audio streams
- store `youtube_id` in `AudioTrack` model
- update player to fetch audio via `YoutubeAudioService`
- adjust backend models, seeds and tests for new field
- update repository and widget tests

## Testing
- `black backend/app/models/audio.py backend/app/schemas/audio.py backend/app/db/seed.py backend/tests/test_home_api.py backend/tests/test_list_endpoints.py backend/tests/test_music_api.py`
- `ruff check backend/app/models/audio.py backend/app/schemas/audio.py backend/app/db/seed.py backend/tests/test_home_api.py backend/tests/test_list_endpoints.py backend/tests/test_music_api.py`
- `pytest backend/tests` *(fails: Missing environment variables)*
- `dart format -o none lib test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862cd9399788324ac42d606b153d14c