### PR TITLE
Add scheduled music recommendation task

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Local notifications are powered by `flutter_local_notifications`. The
 `NotificationService` is initialized in `main.dart` and automatically polls the
 `/quotes/latest` endpoint every 15 minutes. When a new quote is found a
 notification is shown and tapping it opens the quote detail screen.
+The app also polls `/music/latest` every 10 minutes to update the home screen
+with the newest song recommendation.
 
 On Android the default app icon is used for the notification. No additional
 configuration is required other than granting notification permissions on first
@@ -109,6 +111,9 @@ curl "http://localhost:8000/api/v1/music?mood=happy" -H "Authorization: Bearer <
 # get a song based on your last five journals
     curl http://localhost:8000/api/v1/music/recommend \
      -H "Authorization: Bearer <token>"
+
+# fetch the most recently scheduled recommendation
+curl http://localhost:8000/api/v1/music/latest
 ```
 
 ### Spotify Web API

--- a/backend/README.md
+++ b/backend/README.md
@@ -40,3 +40,5 @@ celery -A app.celery_app.celery_app beat --loglevel=info
 ```
 
 The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new quote based on recent journal moods.
+The `generate_music_recommendation_task` runs every 10 minutes and stores the latest
+recommended track in memory for the `/music/latest` endpoint.

--- a/backend/app/api/v1/music.py
+++ b/backend/app/api/v1/music.py
@@ -10,6 +10,7 @@ import re
 from app import crud, models, schemas, dependencies
 from app.core.config import settings
 from app.services.music_keyword_service import MusicKeywordService
+from app.state.music import get_latest_music as _get_latest_music
 
 router = APIRouter()
 log = structlog.get_logger(__name__)
@@ -158,3 +159,9 @@ async def recommend_music(
             musics = []
 
     return musics
+
+
+@router.get("/latest", response_model=schemas.AudioTrack | None)
+def get_latest_music() -> schemas.AudioTrack | None:
+    """Return the most recently generated music recommendation."""
+    return _get_latest_music()

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -11,13 +11,17 @@ celery_app = Celery(
     "tasks",
     broker=redis_url,
     backend=redis_url,
-    include=["app.tasks"] # Tunjuk ke file tempat task didefinisikan
+    include=["app.tasks"],  # Tunjuk ke file tempat task didefinisikan
 )
 
 celery_app.conf.beat_schedule = {
     "generate-quote": {
         "task": "app.tasks.generate_quote_task",
         "schedule": 60 * 15,
-    }
+    },
+    "generate-music": {
+        "task": "app.tasks.generate_music_recommendation_task",
+        "schedule": 60 * 10,
+    },
 }
 celery_app.conf.timezone = "UTC"

--- a/backend/app/state/music.py
+++ b/backend/app/state/music.py
@@ -1,0 +1,15 @@
+from typing import Optional
+from app.schemas.audio import AudioTrack
+
+_latest_music: Optional[AudioTrack] = None
+
+
+def set_latest_music(track: AudioTrack) -> None:
+    """Store the latest music recommendation in memory."""
+    global _latest_music
+    _latest_music = track
+
+
+def get_latest_music() -> Optional[AudioTrack]:
+    """Return the most recent music recommendation if available."""
+    return _latest_music

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -4,6 +4,15 @@ from app.celery_app import celery_app
 from app.services.profile_analyzer_service import profile_analyzer
 from app.db.session import SessionLocal
 from app import crud
+import asyncio
+from app.services.quote_generation_service import QuoteGenerationService
+from app.schemas.motivational_quote import MotivationalQuoteCreate
+from app import models
+from app.api.v1.music import get_spotify, _process_search_results
+from app.services.music_keyword_service import MusicKeywordService
+from app.state.music import set_latest_music
+import re
+
 
 @celery_app.task
 def analyze_profile_task(user_id: int):
@@ -19,17 +28,15 @@ def analyze_profile_task(user_id: int):
         db.close()
     return f"Profile analysis complete for user_id {user_id}"
 
-import asyncio
-from app.services.quote_generation_service import QuoteGenerationService
-from app.schemas.motivational_quote import MotivationalQuoteCreate
-from app import models
 
 @celery_app.task
 def generate_quote_task():
     """Generate a motivational quote based on the latest journal mood."""
     db = SessionLocal()
     try:
-        latest = db.query(models.Journal).order_by(models.Journal.created_at.desc()).first()
+        latest = (
+            db.query(models.Journal).order_by(models.Journal.created_at.desc()).first()
+        )
         mood = latest.mood if latest and latest.mood else "Netral"
         service = QuoteGenerationService()
         text, author = asyncio.run(service.generate_quote(mood))
@@ -41,3 +48,62 @@ def generate_quote_task():
     finally:
         db.close()
     return "Quote generation complete"
+
+
+@celery_app.task
+def generate_music_recommendation_task():
+    """Generate and store a music recommendation."""
+    db = SessionLocal()
+    try:
+        user = db.query(models.User).first()
+        if not user:
+            return "No users available"
+
+        journals = crud.journal.get_multi_by_owner(
+            db=db, owner_id=user.id, limit=5, order_by="created_at desc"
+        )
+
+        musics = []
+        if journals:
+            try:
+                raw_keyword = asyncio.run(
+                    MusicKeywordService().generate_keyword(journals)
+                )
+                cleaned = re.sub(r"[^a-zA-Z0-9\s]", "", raw_keyword).strip()
+                if cleaned:
+                    client = get_spotify()
+                    search_results = client.search(q=cleaned, type="track", limit=20)
+                    musics = _process_search_results(search_results)
+                if not musics:
+                    mood = journals[0].mood
+                    fallback_map = {
+                        "Sangat Negatif": "lagu sedih",
+                        "Negatif": "lagu galau",
+                        "Netral": "lofi hip hop instrumental",
+                        "Positif": "lagu semangat",
+                        "Sangat Positif": "lagu ceria playlist",
+                    }
+                    keyword = fallback_map.get(mood, "musik instrumental santai")
+                    client = get_spotify()
+                    search_results_fallback = client.search(
+                        q=keyword, type="track", limit=20
+                    )
+                    musics = _process_search_results(search_results_fallback)
+            except Exception:
+                musics = []
+
+        if not musics:
+            try:
+                client = get_spotify()
+                default_results = client.search(
+                    q="top hits indonesia", type="track", limit=20
+                )
+                musics = _process_search_results(default_results)
+            except Exception:
+                musics = []
+
+        if musics:
+            set_latest_music(musics[0])
+    finally:
+        db.close()
+    return "Music recommendation complete"

--- a/backend/tests/test_list_endpoints.py
+++ b/backend/tests/test_list_endpoints.py
@@ -76,3 +76,22 @@ def test_quotes_latest_endpoint_returns_latest_item(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["text"] == "new"
+
+
+def test_music_latest_endpoint_returns_none_by_default(client):
+    client_app, _ = client
+    resp = client_app.get("/api/v1/music/latest")
+    assert resp.status_code == 200
+    assert resp.json() is None
+
+
+def test_music_latest_endpoint_returns_track(client):
+    from app.state.music import set_latest_music
+    from app.schemas.audio import AudioTrack
+
+    set_latest_music(AudioTrack(id=1, title="t", youtube_id="y"))
+    client_app, _ = client
+    resp = client_app.get("/api/v1/music/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "t"

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -37,6 +37,7 @@ import '../../domain/usecases/get_chat_history_usecase.dart' as _i992;
 import '../../domain/usecases/get_home_feed_usecase.dart' as _i1028;
 import '../../domain/usecases/get_journals_usecase.dart' as _i738;
 import '../../domain/usecases/get_latest_quote_usecase.dart' as _i789;
+import '../../domain/usecases/get_latest_music_usecase.dart' as _i1080;
 import '../../domain/usecases/get_user_profile_usecase.dart' as _i629;
 import '../../domain/usecases/login_usecase.dart' as _i253;
 import '../../domain/usecases/logout_usecase.dart' as _i981;
@@ -53,6 +54,7 @@ import '../../presentation/journal/cubit/journal_editor_cubit.dart' as _i826;
 import '../../presentation/profile/cubit/profile_cubit.dart' as _i107;
 import '../../services/notification_service.dart' as _i85;
 import '../../services/quote_update_service.dart' as _i642;
+import '../../services/music_update_service.dart' as _i1100;
 import '../../services/youtube_audio_service.dart' as _i221;
 import '../api/auth_interceptor.dart' as _i577;
 import '../api/logging_interceptor.dart' as _i427;
@@ -119,6 +121,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i789.GetLatestQuoteUseCase>(
       () => _i789.GetLatestQuoteUseCase(gh<_i826.HomeRepository>()),
     );
+    gh.factory<_i1080.GetLatestMusicUseCase>(
+      () => _i1080.GetLatestMusicUseCase(gh<_i826.HomeRepository>()),
+    );
     gh.factory<_i1028.GetHomeFeedUseCase>(
       () => _i1028.GetHomeFeedUseCase(gh<_i826.HomeRepository>()),
     );
@@ -147,6 +152,11 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i642.QuoteUpdateService(
         gh<_i1004.HomeApiService>(),
         gh<_i85.NotificationService>(),
+      ),
+    );
+    gh.lazySingleton<_i1100.MusicUpdateService>(
+      () => _i1100.MusicUpdateService(
+        gh<_i1004.HomeApiService>(),
       ),
     );
     gh.lazySingleton<_i1073.AuthRepository>(

--- a/lib/data/datasources/remote/home_api_service.dart
+++ b/lib/data/datasources/remote/home_api_service.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 import 'package:dear_flutter/domain/entities/home_feed_item.dart';
 import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
 
 @injectable
 class HomeApiService {
@@ -20,5 +21,10 @@ class HomeApiService {
     final response = await _dio.get('quotes/latest/');
     return MotivationalQuote.fromJson(
         response.data as Map<String, dynamic>);
+  }
+
+  Future<AudioTrack> getLatestMusic() async {
+    final response = await _dio.get('music/latest/');
+    return AudioTrack.fromJson(response.data as Map<String, dynamic>);
   }
 }

--- a/lib/data/repositories/home_repository_impl.dart
+++ b/lib/data/repositories/home_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:injectable/injectable.dart';
 import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
 import 'package:dear_flutter/domain/entities/home_feed_item.dart';
 import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
 import 'package:dear_flutter/domain/repositories/home_repository.dart';
 
 @LazySingleton(as: HomeRepository)
@@ -18,5 +19,10 @@ class HomeRepositoryImpl implements HomeRepository {
   @override
   Future<MotivationalQuote> getLatestQuote() {
     return _apiService.getLatestQuote();
+  }
+
+  @override
+  Future<AudioTrack> getLatestMusic() {
+    return _apiService.getLatestMusic();
   }
 }

--- a/lib/domain/repositories/home_repository.dart
+++ b/lib/domain/repositories/home_repository.dart
@@ -1,7 +1,9 @@
 import 'package:dear_flutter/domain/entities/home_feed_item.dart';
 import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
 
 abstract class HomeRepository {
   Future<List<HomeFeedItem>> getHomeFeed();
   Future<MotivationalQuote> getLatestQuote();
+  Future<AudioTrack> getLatestMusic();
 }

--- a/lib/domain/usecases/get_latest_music_usecase.dart
+++ b/lib/domain/usecases/get_latest_music_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/domain/repositories/home_repository.dart';
+
+@injectable
+class GetLatestMusicUseCase {
+  final HomeRepository _repository;
+  GetLatestMusicUseCase(this._repository);
+
+  Future<AudioTrack> call() => _repository.getLatestMusic();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:dear_flutter/core/di/injection.dart';
 import 'package:dear_flutter/core/navigation/app_router.dart'; // Router konfigurasi
 import 'package:dear_flutter/services/notification_service.dart';
 import 'package:dear_flutter/services/quote_update_service.dart';
+import 'package:dear_flutter/services/music_update_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -11,6 +12,7 @@ Future<void> main() async {
   await configureDependencies();
   await getIt<NotificationService>().init();
   getIt<QuoteUpdateService>().start();
+  getIt<MusicUpdateService>().start();
 
   runApp(const MyApp());
 }

--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:injectable/injectable.dart';
+
+@LazySingleton()
+class MusicUpdateService {
+  final HomeApiService _apiService;
+
+  Timer? _timer;
+  AudioTrack? _latest;
+
+  MusicUpdateService(this._apiService);
+
+  void start() {
+    _timer?.cancel();
+    _fetch();
+    _timer = Timer.periodic(const Duration(minutes: 10), (_) => _fetch());
+  }
+
+  AudioTrack? get latest => _latest;
+
+  Future<void> _fetch() async {
+    try {
+      final track = await _apiService.getLatestMusic();
+      _latest = track;
+    } catch (_) {
+      // ignore errors
+    }
+  }
+
+  void dispose() {
+    _timer?.cancel();
+  }
+}


### PR DESCRIPTION
## Summary
- schedule a celery task to generate music recommendations
- expose `/music/latest` to return the in-memory recommendation
- poll this endpoint from Flutter using `MusicUpdateService`
- document the new behaviour and endpoints
- cover `/music/latest` with tests

## Testing
- `ruff check backend/app/tasks.py backend/app/api/v1/music.py backend/app/celery_app.py backend/app/state/music.py backend/tests/test_list_endpoints.py`
- `black backend/app/api/v1/music.py backend/app/tasks.py backend/app/celery_app.py backend/app/state backend/tests/test_list_endpoints.py`
- `dart format -o none lib/ backend/` *(fails: dart not installed)*
- `dart analyze` *(fails: dart not installed)*
- `pytest -q backend/tests/test_list_endpoints.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6862e4a42e848324b15ebced5a37bb51