### PR TITLE
Fix latest music fetch

### DIFF
--- a/lib/data/datasources/remote/home_api_service.dart
+++ b/lib/data/datasources/remote/home_api_service.dart
@@ -14,8 +14,10 @@ class HomeApiService {
         response.data as Map<String, dynamic>);
   }
 
-  Future<AudioTrack> getLatestMusic() async {
+  Future<AudioTrack?> getLatestMusic() async {
     final response = await _dio.get('music/latest/');
-    return AudioTrack.fromJson(response.data as Map<String, dynamic>);
+    final data = response.data;
+    if (data == null) return null;
+    return AudioTrack.fromJson(data as Map<String, dynamic>);
   }
 }

--- a/lib/data/repositories/home_repository_impl.dart
+++ b/lib/data/repositories/home_repository_impl.dart
@@ -16,7 +16,7 @@ class HomeRepositoryImpl implements HomeRepository {
   }
 
   @override
-  Future<AudioTrack> getLatestMusic() {
+  Future<AudioTrack?> getLatestMusic() {
     return _apiService.getLatestMusic();
   }
 }

--- a/lib/domain/repositories/home_repository.dart
+++ b/lib/domain/repositories/home_repository.dart
@@ -3,5 +3,5 @@ import 'package:dear_flutter/domain/entities/audio_track.dart';
 
 abstract class HomeRepository {
   Future<MotivationalQuote> getLatestQuote();
-  Future<AudioTrack> getLatestMusic();
+  Future<AudioTrack?> getLatestMusic();
 }

--- a/lib/domain/usecases/get_latest_music_usecase.dart
+++ b/lib/domain/usecases/get_latest_music_usecase.dart
@@ -7,5 +7,5 @@ class GetLatestMusicUseCase {
   final HomeRepository _repository;
   GetLatestMusicUseCase(this._repository);
 
-  Future<AudioTrack> call() => _repository.getLatestMusic();
+  Future<AudioTrack?> call() => _repository.getLatestMusic();
 }


### PR DESCRIPTION
## Summary
- handle `null` responses when requesting latest music

## Testing
- `dart format lib/data/datasources/remote/home_api_service.dart lib/data/repositories/home_repository_impl.dart lib/domain/repositories/home_repository.dart lib/domain/usecases/get_latest_music_usecase.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `black . --check` *(fails: would reformat multiple files)*
- `ruff check .` *(fails: several lint errors)*
- `flutter test` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6862f09dd00483249dea5ca697578dc3