### PR TITLE
Update music recommendation schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Local notifications are powered by `flutter_local_notifications`. The
 `NotificationService` is initialized in `main.dart` and automatically polls the
 `/quotes/latest` endpoint every 15 minutes. When a new quote is found a
 notification is shown and tapping it opens the quote detail screen.
-The app also polls `/music/latest` every 10 minutes to update the home screen
+The app also polls `/music/latest` every 15 minutes to update the home screen
 with the newest song recommendation.
 
 On Android the default app icon is used for the notification. No additional

--- a/backend/README.md
+++ b/backend/README.md
@@ -40,5 +40,5 @@ celery -A app.celery_app.celery_app beat --loglevel=info
 ```
 
 The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new quote based on recent journal moods.
-The `generate_music_recommendation_task` runs every 10 minutes and stores the latest
+The `generate_music_recommendation_task` runs every 15 minutes and stores the latest
 recommended track in memory for the `/music/latest` endpoint.

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -21,7 +21,7 @@ celery_app.conf.beat_schedule = {
     },
     "generate-music": {
         "task": "app.tasks.generate_music_recommendation_task",
-        "schedule": 60 * 10,
+        "schedule": 60 * 15,
     },
 }
 celery_app.conf.timezone = "UTC"

--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -16,7 +16,7 @@ class MusicUpdateService {
   void start() {
     _timer?.cancel();
     _fetch();
-    _timer = Timer.periodic(const Duration(minutes: 10), (_) => _fetch());
+    _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
   List<SongSuggestion> get latest => _latest;


### PR DESCRIPTION
## Summary
- adjust Celery beat interval for `generate_music_recommendation_task`
- poll `/music/latest` every 15 minutes in the client
- document new 15‑minute interval in the backend and root READMEs

## Testing
- `black backend/app/celery_app.py`
- `ruff check backend/app/celery_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686343065f648324b25cfb651eca25c3