### PR TITLE
Add isolated manifest parsing for YouTube audio

### DIFF
--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -2,6 +2,7 @@ import 'package:dear_flutter/services/youtube_audio_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   test('returns highest bitrate url', () async {
     final service = YoutubeAudioService(fetcher: (id) async => [
       AudioInfo(128, Uri.parse('u1')),


### PR DESCRIPTION
## Summary
- parse the YouTube audio manifest in a top-level function
- run parsing in an isolate with `compute`
- init Flutter binding in audio service test

## Related Issues
- Closes #?? (no issue specified)

## Files Affected
- `lib/services/youtube_audio_service.dart`
- `test/youtube_audio_service_test.dart`

## Testing
- `dart format lib/services/youtube_audio_service.dart test/youtube_audio_service_test.dart` *(fails: `dart` not found)*
- `dart analyze` *(fails: `dart` not found)*
- `flutter test` *(fails: `flutter` not found)*


------
https://chatgpt.com/codex/tasks/task_e_68634d89cdf083248b27cf991b2da614