### PR TITLE
Add methods to clear local data and integrate with logout

### DIFF
--- a/backend/migrations/versions/d0a3eee022e6_.py
+++ b/backend/migrations/versions/d0a3eee022e6_.py
@@ -9,7 +9,6 @@ Create Date: 2025-06-29 09:40:11.232533
 from typing import Sequence, Union
 
 
-
 # revision identifiers, used by Alembic.
 revision: str = "d0a3eee022e6"
 down_revision: Union[str, Sequence[str], None] = "2408f58c1b6b"

--- a/backend/migrations/versions/da8b31e2805d_.py
+++ b/backend/migrations/versions/da8b31e2805d_.py
@@ -9,7 +9,6 @@ Create Date: 2025-06-24 17:41:39.072944
 from typing import Sequence, Union
 
 
-
 # revision identifiers, used by Alembic.
 revision: str = "da8b31e2805d"
 down_revision: Union[str, Sequence[str], None] = "fb0cdebfcd18"

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -217,6 +217,7 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i629.GetUserProfileUseCase>(),
         gh<_i981.LogoutUseCase>(),
         gh<_i874.DeleteAccountUseCase>(),
+        gh<_i483.AppDatabase>(),
       ),
     );
     return this;

--- a/lib/data/datasources/local/app_database.dart
+++ b/lib/data/datasources/local/app_database.dart
@@ -19,6 +19,11 @@ class AppDatabase extends _$AppDatabase {
 
   @override
   int get schemaVersion => 4;
+
+  Future<void> clearAllData() async {
+    await journalDao.deleteAllJournals();
+    await chatMessageDao.deleteAllMessages();
+  }
 }
 
 LazyDatabase _openConnection() {

--- a/lib/data/datasources/local/chat_message_dao.dart
+++ b/lib/data/datasources/local/chat_message_dao.dart
@@ -19,4 +19,7 @@ class ChatMessageDao extends DatabaseAccessor<AppDatabase> with _$ChatMessageDao
   // Menghapus pesan berdasarkan ID
   Future<void> deleteMessageById(String id) =>
       (delete(chatMessages)..where((tbl) => tbl.id.equals(id))).go();
+
+  Future<void> deleteAllMessages() =>
+      delete(chatMessages).go();
 }

--- a/lib/data/datasources/local/journal_dao.dart
+++ b/lib/data/datasources/local/journal_dao.dart
@@ -21,4 +21,7 @@ class JournalDao extends DatabaseAccessor<AppDatabase> with _$JournalDaoMixin {
 
   Future<void> deleteJournalById(int id) =>
       (delete(journalEntries)..where((tbl) => tbl.id.equals(id))).go();
+
+  Future<void> deleteAllJournals() =>
+      delete(journalEntries).go();
 }

--- a/lib/presentation/profile/cubit/profile_cubit.dart
+++ b/lib/presentation/profile/cubit/profile_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:dear_flutter/domain/usecases/get_user_profile_usecase.dart';
 import 'package:dear_flutter/domain/usecases/logout_usecase.dart';
 import 'package:dear_flutter/domain/usecases/delete_account_usecase.dart';
+import 'package:dear_flutter/data/datasources/local/app_database.dart';
 import 'package:dear_flutter/presentation/profile/cubit/profile_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
@@ -10,11 +11,13 @@ class ProfileCubit extends Cubit<ProfileState> {
   final GetUserProfileUseCase _getUserProfileUseCase;
   final LogoutUseCase _logoutUseCase;
   final DeleteAccountUseCase _deleteAccountUseCase;
+  final AppDatabase _db;
 
   ProfileCubit(
       this._getUserProfileUseCase,
       this._logoutUseCase,
       this._deleteAccountUseCase,
+      this._db,
       ) : super(const ProfileState()) {
     fetchUserProfile();
   }
@@ -31,6 +34,7 @@ class ProfileCubit extends Cubit<ProfileState> {
 
   Future<void> logout() async {
     await _logoutUseCase();
+    await _db.clearAllData();
   }
 
   Future<void> deleteAccount() async {


### PR DESCRIPTION
## Summary
- add deleteAllJournals and deleteAllMessages DAO helpers
- expose clearAllData helper in `AppDatabase`
- inject database into `ProfileCubit` and clear local data on logout
- update `injection.config.dart`
- run formatters

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart run build_runner build --delete-conflicting-outputs` *(fails: command not found)*
- `black backend`
- `ruff check backend`
- `pytest backend` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68635231777c8324abd7ffc86c02a266