### PR TITLE
Fix trailing output in backend README

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,4 @@ celery -A app.celery_app.celery_app worker --loglevel=info
 celery -A app.celery_app.celery_app beat --loglevel=info
 ```
 
-The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new quote based on recent journal moods.
-The `generate_music_recommendation_task` runs every 15 minutes and stores the latest
-recommended track in memory for the `/music/latest` endpoint.
+The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new quote based on recent journal moods. The `generate_music_recommendation_task` runs every 15 minutes and stores the latest recommended track in memory for the `/music/latest` endpoint.


### PR DESCRIPTION
## Summary
- clean up README formatting in backend

## Testing
- `ruff check backend`
- `black backend`

------
https://chatgpt.com/codex/tasks/task_e_6863538bf22083249017bb967635df4d