### PR TITLE
Update music suggestion flow with mood parameter

### DIFF
--- a/lib/data/datasources/remote/home_api_service.dart
+++ b/lib/data/datasources/remote/home_api_service.dart
@@ -22,8 +22,11 @@ class HomeApiService {
     return AudioTrack.fromJson(data as Map<String, dynamic>);
   }
 
-  Future<List<SongSuggestion>> getSuggestedMusic() async {
-    final response = await _dio.get('music/recommend/');
+  Future<List<SongSuggestion>> getSuggestedMusic(String mood) async {
+    final response = await _dio.get(
+      'music/recommend/',
+      queryParameters: {'mood': mood},
+    );
     final data = response.data as List<dynamic>;
     return data
         .map((e) => SongSuggestion.fromJson(e as Map<String, dynamic>))

--- a/lib/data/repositories/home_repository_impl.dart
+++ b/lib/data/repositories/home_repository_impl.dart
@@ -22,7 +22,7 @@ class HomeRepositoryImpl implements HomeRepository {
   }
 
   @override
-  Future<List<SongSuggestion>> getMusicSuggestions() {
-    return _apiService.getSuggestedMusic();
+  Future<List<SongSuggestion>> getMusicSuggestions(String mood) {
+    return _apiService.getSuggestedMusic(mood);
   }
 }

--- a/lib/domain/repositories/home_repository.dart
+++ b/lib/domain/repositories/home_repository.dart
@@ -5,5 +5,5 @@ import 'package:dear_flutter/domain/entities/song_suggestion.dart';
 abstract class HomeRepository {
   Future<MotivationalQuote> getLatestQuote();
   Future<AudioTrack?> getLatestMusic();
-  Future<List<SongSuggestion>> getMusicSuggestions();
+  Future<List<SongSuggestion>> getMusicSuggestions(String mood);
 }

--- a/lib/domain/usecases/get_music_suggestions_usecase.dart
+++ b/lib/domain/usecases/get_music_suggestions_usecase.dart
@@ -7,5 +7,6 @@ class GetMusicSuggestionsUseCase {
   final HomeRepository _repository;
   GetMusicSuggestionsUseCase(this._repository);
 
-  Future<List<SongSuggestion>> call() => _repository.getMusicSuggestions();
+  Future<List<SongSuggestion>> call(String mood) =>
+      _repository.getMusicSuggestions(mood);
 }

--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -15,7 +15,7 @@ class LatestMusicCubit extends Cubit<LatestMusicState> {
   Future<void> fetchLatestMusic() async {
     emit(state.copyWith(status: LatestMusicStatus.loading));
     try {
-      final suggestions = await _getMusicSuggestionsUseCase();
+      final suggestions = await _getMusicSuggestionsUseCase('Netral');
       emit(state.copyWith(
           status: LatestMusicStatus.success, suggestions: suggestions));
     } catch (_) {

--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -23,7 +23,7 @@ class MusicUpdateService {
 
   Future<void> _fetch() async {
     try {
-      final suggestions = await _apiService.getSuggestedMusic();
+      final suggestions = await _apiService.getSuggestedMusic('Netral');
       _latest = suggestions;
     } catch (_) {
       // ignore errors


### PR DESCRIPTION
## Summary
- pass mood query when fetching music suggestions
- adapt repository and use case APIs for mood argument
- update `LatestMusicCubit` and `MusicUpdateService` to request music for a neutral mood

## Testing
- `dart run build_runner build --delete-conflicting-outputs` *(fails: dart not found)*
- `dart format .` *(fails: dart not found)*
- `dart analyze` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_686359aa104c83248f0f38bc3efa91e4