### PR TITLE
Fix home feed keyword generation

### DIFF
--- a/backend/app/api/v1/home.py
+++ b/backend/app/api/v1/home.py
@@ -16,10 +16,16 @@ async def get_home_feed(
     """Return combined recent content for the home screen."""
     articles = crud.article.get_multi(db)
     quotes = crud.motivational_quote.get_multi(db)
+
+    journals = crud.journal.get_multi_by_owner(
+        db=db, owner_id=current_user.id, limit=5, order_by="created_at desc"
+    )
+    keyword = await MusicKeywordService().generate_keyword(journals)
+
     audio_tracks = await recommend_music(
+        mood=keyword,
         db=db,
         current_user=current_user,
-        keyword_service=MusicKeywordService(),
     )
 
     items = []

--- a/backend/tests/test_home_api.py
+++ b/backend/tests/test_home_api.py
@@ -19,10 +19,17 @@ def test_home_feed_structure_and_ordering(client, monkeypatch):
     finally:
         db.close()
 
-    async def fake_recommend_music(**kwargs):
+    async def fake_recommend_music(*, mood: str, **kwargs):
+        assert mood == "lofi"
         return [AudioTrack(id=99, title="rec", youtube_id="y1")]
 
+    async def fake_generate_keyword(self, journals):
+        return "lofi"
+
     monkeypatch.setattr(home_api, "recommend_music", fake_recommend_music)
+    monkeypatch.setattr(
+        home_api.MusicKeywordService, "generate_keyword", fake_generate_keyword
+    )
 
     resp = client_app.get("/api/v1/home-feed")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- generate keyword from journals on `/home-feed`
- validate mood is passed to `recommend_music`
- update unit test

## Testing
- `black backend`
- `ruff check backend`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635ac9da048324aa743bc670f165d2