### PR TITLE
Add missing test dependency script

### DIFF
--- a/scripts/install-test-deps.sh
+++ b/scripts/install-test-deps.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Install backend test requirements for Dear Diary
+set -e
+pip install -r backend/requirements.txt
+pip install pytest pytest-asyncio


### PR DESCRIPTION
## Summary
- implement `scripts/install-test-deps.sh` referenced in README

## Testing
- `black .`
- `ruff check .`
- `pytest backend/tests` *(fails: missing environment variables)*
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686368c1f3748324979e5964d8aeae3e