### PR TITLE
Streamline Youtube audio fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ client credentials in your `.env` file as shown above.
 ### YouTube Audio Service
 
 Recommended tracks returned by the backend include a `youtube_id` field. The
-Flutter client resolves this ID to a playable stream using
-`lib/services/youtube_audio_service.dart`. The service fetches the available
-audio streams with `youtube_explode_dart`, sorts them by bitrate and returns the
-highest quality URL. No additional YouTube API key is required.
+Flutter client resolves this ID to a playable audio stream using
+`lib/services/youtube_audio_service.dart`. The service keeps a single
+`YoutubeExplode` client around and queries the manifest for audio-only streams.
+These are sorted by bitrate and the highest quality URL is returned. No
+YouTube API key is required.
 
 Audio suggestions come from the `/music/recommend` endpoint which analyses the
 latest journal entries through OpenRouter to generate a search keyword. That


### PR DESCRIPTION
## Summary
- streamline audio stream resolution with YoutubeExplode
- clarify audio service behavior in README

## Testing
- `apt-get update`
- `apt-get install -y apt-transport-https`
- `wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | tee /usr/share/keyrings/dart-archive-keyring.gpg`
- `echo "deb [signed-by=/usr/share/keyrings/dart-archive-keyring.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main" > /etc/apt/sources.list.d/dart_stable.list`
- `apt-get update` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68636dfec8348324a8293c1c030d78c9