### PR TITLE
Fix YoutubeAudioService injectable placement

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -88,8 +88,8 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i109.ChatMessageDao>(
       () => registerModule.chatMessageDao(gh<_i483.AppDatabase>()),
     );
-    gh.lazySingleton<_i221.AudioInfo>(
-      () => _i221.AudioInfo(gh<int>(), gh<Uri>()),
+    gh.lazySingleton<_i221.YoutubeAudioService>(
+      () => _i221.YoutubeAudioService(),
     );
     gh.factory<_i577.AuthInterceptor>(
       () => _i577.AuthInterceptor(gh<_i324.UserPreferencesRepository>()),

--- a/lib/services/youtube_audio_service.dart
+++ b/lib/services/youtube_audio_service.dart
@@ -2,7 +2,6 @@ import 'package:injectable/injectable.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
 /// Service to obtain playable audio streams from YouTube videos.
-@LazySingleton()
 class AudioInfo {
   final int bitrate;
   final Uri url;
@@ -11,6 +10,7 @@ class AudioInfo {
 
 typedef _AudioFetcher = Future<List<AudioInfo>> Function(String id);
 
+@LazySingleton()
 class YoutubeAudioService {
   YoutubeAudioService({YoutubeExplode? client, _AudioFetcher? fetcher})
       : _yt = client ?? YoutubeExplode(),


### PR DESCRIPTION
## Summary
- move `@LazySingleton()` to `YoutubeAudioService`
- regenerate injection configuration

## Testing
- `dart format -o none --set-exit-if-changed lib/services/youtube_audio_service.dart lib/core/di/injection.config.dart`
- `dart analyze`
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6863715ff9948324aaba033106a19feb