### PR TITLE
Integrate Hive storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ flutter pub run build_runner build --delete-conflicting-outputs
 ```
 If Flutter is not available you can also run `dart run build_runner build`.
 
+Hive is used to store playback history. The box is opened automatically when
+`main()` runs, so no manual setup is required beyond ensuring the generated
+code is built.
+
 Run the application on an attached device or emulator:
 
 ```bash

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -58,6 +58,9 @@ import '../../services/quote_update_service.dart' as _i642;
 import '../../services/youtube_audio_service.dart' as _i221;
 import '../api/auth_interceptor.dart' as _i577;
 import '../api/logging_interceptor.dart' as _i427;
+import 'package:hive/hive.dart' as _i1108;
+import '../../domain/repositories/song_history_repository.dart' as _i1109;
+import '../../data/repositories/song_history_repository_impl.dart' as _i1110;
 import 'register_module.dart' as _i291;
 
 extension GetItInjectableX on _i174.GetIt {
@@ -81,6 +84,10 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i324.UserPreferencesRepository>(
       () => _i324.UserPreferencesRepository(gh<_i460.SharedPreferences>()),
+    );
+    await gh.lazySingletonAsync<_i1108.Box<_i1108.Map>>(
+      () => registerModule.songBox,
+      preResolve: true,
     );
     gh.lazySingleton<_i28.JournalDao>(
       () => registerModule.journalDao(gh<_i483.AppDatabase>()),
@@ -134,6 +141,11 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i838.ChatRepositoryImpl(
         gh<_i489.ChatApiService>(),
         gh<_i109.ChatMessageDao>(),
+      ),
+    );
+    gh.lazySingleton<_i1109.SongHistoryRepository>(
+      () => _i1110.SongHistoryRepositoryImpl(
+        gh<_i1108.Box<_i1108.Map>>(),
       ),
     );
     gh.factory<_i992.GetChatHistoryUseCase>(

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -9,6 +9,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:hive/hive.dart';
 
 @module
 abstract class RegisterModule {
@@ -49,4 +50,8 @@ Dio dio(
   @preResolve
   @lazySingleton
   Future<SharedPreferences> get prefs => SharedPreferences.getInstance();
+
+  @preResolve
+  @lazySingleton
+  Future<Box<Map>> get songBox => Hive.openBox<Map>('song_history');
 }

--- a/lib/data/repositories/song_history_repository_impl.dart
+++ b/lib/data/repositories/song_history_repository_impl.dart
@@ -1,0 +1,19 @@
+import 'package:injectable/injectable.dart';
+import 'package:hive/hive.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
+
+@LazySingleton(as: SongHistoryRepository)
+class SongHistoryRepositoryImpl implements SongHistoryRepository {
+  final Box<Map> _box;
+
+  SongHistoryRepositoryImpl(this._box);
+
+  @override
+  Future<void> addTrack(AudioTrack track) => _box.add(track.toJson());
+
+  @override
+  List<AudioTrack> getHistory() => _box.values
+      .map((e) => AudioTrack.fromJson(Map<String, dynamic>.from(e)))
+      .toList();
+}

--- a/lib/domain/repositories/song_history_repository.dart
+++ b/lib/domain/repositories/song_history_repository.dart
@@ -1,0 +1,6 @@
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+
+abstract class SongHistoryRepository {
+  Future<void> addTrack(AudioTrack track);
+  List<AudioTrack> getHistory();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,9 +7,12 @@ import 'package:dear_flutter/services/music_update_service.dart';
 import 'package:audio_service/audio_service.dart';
 import 'services/audio_player_handler.dart';
 import 'services/youtube_audio_service.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  await Hive.initFlutter();
 
   // Inisialisasi dependency injection (getIt, dll.)
   await configureDependencies();

--- a/lib/presentation/home/screens/audio_player_screen.dart
+++ b/lib/presentation/home/screens/audio_player_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:dear_flutter/domain/entities/audio_track.dart';
 import 'package:dear_flutter/services/audio_player_handler.dart';
 import 'package:dear_flutter/core/di/injection.dart';
+import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
 
 class AudioPlayerScreen extends StatefulWidget {
   const AudioPlayerScreen({super.key, required this.track});
@@ -38,6 +39,7 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
     if (_isPlaying) {
       await _handler.pause();
     } else {
+      await getIt<SongHistoryRepository>().addTrack(widget.track);
       await _handler.playFromYoutubeId(widget.track.youtubeId);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
   audio_service: ^0.18.18               # Layanan audio latar belakang
   flutter_local_notifications: ^19.3.0
   youtube_explode_dart: ^2.4.2
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `hive` dependencies
- configure Hive box via DI
- save played tracks to Hive history
- initialize Hive in `main.dart`
- document Hive setup in README

## Testing
- `dart format -o none lib` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6863825e40b0832484900f39b95f8e59