### PR TITLE
Fix dependency injection warnings

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 import 'package:dear_flutter/services/audio_player_handler.dart';
 import 'package:dear_flutter/services/youtube_audio_service.dart';
+import 'package:just_audio/just_audio.dart';
 
 import 'injection.config.dart'; // File ini akan dibuat oleh generator
 
@@ -19,7 +20,10 @@ Future<GetIt> configureDependencies() async {
   // Manual registrations not covered by code generation
   if (!getIt.isRegistered<AudioPlayerHandler>()) {
     getIt.registerLazySingleton<AudioPlayerHandler>(
-      () => AudioPlayerHandler(getIt<YoutubeAudioService>()),
+      () => AudioPlayerHandler(
+        getIt<YoutubeAudioService>(),
+        player: getIt<AudioPlayer>(),
+      ),
     );
   }
   return getIt;

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -10,6 +10,8 @@ import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:hive/hive.dart';
+import 'package:youtube_explode_dart/youtube_explode_dart.dart';
+import 'package:just_audio/just_audio.dart';
 
 @module
 abstract class RegisterModule {
@@ -54,4 +56,11 @@ Dio dio(
   @preResolve
   @lazySingleton
   Future<Box<Map>> get songBox => Hive.openBox<Map>('song_history');
+
+  // --- AUDIO ---
+  @lazySingleton
+  YoutubeExplode youtubeExplode() => YoutubeExplode();
+
+  @lazySingleton
+  AudioPlayer audioPlayer() => AudioPlayer();
 }


### PR DESCRIPTION
## Summary
- register YoutubeExplode and AudioPlayer in the DI module
- supply AudioPlayer when manually creating `AudioPlayerHandler`

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638641430c8324a1294bbaf45ddef8