### PR TITLE
fix(di): register audio dependencies

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -13,6 +13,8 @@ import 'package:dio/dio.dart' as _i361;
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 import 'package:shared_preferences/shared_preferences.dart' as _i460;
+import 'package:youtube_explode_dart/youtube_explode_dart.dart' as _i1111;
+import 'package:just_audio/just_audio.dart' as _i1112;
 
 import '../../data/datasources/local/app_database.dart' as _i483;
 import '../../data/datasources/local/chat_message_dao.dart' as _i109;
@@ -94,6 +96,12 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i109.ChatMessageDao>(
       () => registerModule.chatMessageDao(gh<_i483.AppDatabase>()),
+    );
+    gh.lazySingleton<_i1111.YoutubeExplode>(
+      () => registerModule.youtubeExplode(),
+    );
+    gh.lazySingleton<_i1112.AudioPlayer>(
+      () => registerModule.audioPlayer(),
     );
     gh.lazySingleton<_i221.YoutubeAudioService>(
       () => _i221.YoutubeAudioService(),


### PR DESCRIPTION
## Summary
- register `YoutubeExplode` and `AudioPlayer` in generated injection file

## Testing
- `pytest -q` *(fails: ValidationError for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_6863881e32888324a41cb0ca8172aa9f