### PR TITLE
Fix audio handler stop cleanup

### DIFF
--- a/lib/services/audio_player_handler.dart
+++ b/lib/services/audio_player_handler.dart
@@ -59,12 +59,10 @@ class AudioPlayerHandler extends BaseAudioHandler {
   Future<void> pause() => _player.pause();
 
   @override
-  Future<void> stop() => _player.stop();
-
-  @override
-  Future<void> close() async {
+  Future<void> stop() async {
     await _player.dispose();
     _youtube.close();
-    await super.close();
+    return super.stop();
   }
+
 }

--- a/test/audio_player_handler_test.dart
+++ b/test/audio_player_handler_test.dart
@@ -50,4 +50,19 @@ void main() {
     final state = await future;
     expect(state.playing, isTrue);
   });
+
+  test('stop disposes player and closes youtube', () async {
+    final player = _MockAudioPlayer();
+    final yt = _MockYoutubeService();
+
+    when(player.dispose).thenAnswer((_) async {});
+    when(() => yt.close()).thenReturn(null);
+
+    final handler = AudioPlayerHandler(yt, player: player);
+
+    await handler.stop();
+
+    verify(player.dispose).called(1);
+    verify(() => yt.close()).called(1);
+  });
 }


### PR DESCRIPTION
## Summary
- dispose AudioPlayer in `stop`
- close YoutubeAudioService when stopping
- test that stopping disposes resources

## Testing
- `dart format .` *(fails: dart not installed)*
- `dart analyze` *(fails: dart not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68638cdb70e48324976f00b4ca1f0ed8