### PR TITLE
Fix lints from analyzer

### DIFF
--- a/lib/data/datasources/remote/chat_api_service.dart
+++ b/lib/data/datasources/remote/chat_api_service.dart
@@ -15,7 +15,7 @@ class ChatRequest with _$ChatRequest {
 @freezed
 class ChatResponse with _$ChatResponse {
   const factory ChatResponse({
-    @JsonKey(name: 'content')
+    @JsonKey(name: 'content') // ignore: invalid_annotation_target
     required String reply,
     String? emotion,
   }) = _ChatResponse;

--- a/lib/domain/entities/audio_track.dart
+++ b/lib/domain/entities/audio_track.dart
@@ -8,7 +8,7 @@ class AudioTrack with _$AudioTrack {
   const factory AudioTrack({
     required int id,
     required String title,
-    @JsonKey(name: 'youtube_id')
+    @JsonKey(name: 'youtube_id') // ignore: invalid_annotation_target
     required String youtubeId,
   }) = _AudioTrack;
 

--- a/lib/domain/entities/journal.dart
+++ b/lib/domain/entities/journal.dart
@@ -19,9 +19,9 @@ class Journal with _$Journal {
     
     // Di Kotlin: createdAt: OffsetDateTime
     // Di Dart, kita gunakan DateTime. json_serializable akan meng-handle konversinya.
-    // Anotasi @JsonKey digunakan untuk mencocokkan nama field dari JSON API.
-    @JsonKey(name: 'created_at')
-    required DateTime createdAt,
+      // Anotasi @JsonKey digunakan untuk mencocokkan nama field dari JSON API.
+      @JsonKey(name: 'created_at') // ignore: invalid_annotation_target
+      required DateTime createdAt,
   }) = _Journal;
 
   // Factory ini penting agar kita bisa membuat objek Journal dari JSON.

--- a/lib/presentation/chat/screens/chat_screen.dart
+++ b/lib/presentation/chat/screens/chat_screen.dart
@@ -86,7 +86,9 @@ class _ChatMessageBubble extends StatelessWidget {
   Widget build(BuildContext context) {
     final isUser = message.role == 'user';
     final alignment = isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start;
-    final color = isUser ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.surfaceVariant;
+    final color = isUser
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colorScheme.surfaceContainerHighest;
     final textColor = isUser ? Theme.of(context).colorScheme.onPrimary : Theme.of(context).colorScheme.onSurfaceVariant;
 
     return Container(

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -42,8 +42,7 @@ class HomeScreen extends StatelessWidget {
                 ),
                 const SizedBox(height: 16),
                 ...state.suggestions
-                    .map((s) => _MusicCard(suggestion: s))
-                    .toList(),
+                    .map((s) => _MusicCard(suggestion: s)),
               ],
             );
           },

--- a/test/profile_cubit_test.dart
+++ b/test/profile_cubit_test.dart
@@ -7,7 +7,6 @@ import 'package:dear_flutter/domain/usecases/logout_usecase.dart';
 import 'package:dear_flutter/presentation/profile/cubit/profile_cubit.dart';
 import 'package:dear_flutter/data/datasources/local/app_database.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 
 class _FakeAuthRepository implements AuthRepository {
   bool deleteCalled = false;

--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -26,7 +26,7 @@ void main() {
 
   test('throws when _AudioFetcher throws for invalid id', () async {
     final service = YoutubeAudioService(YoutubeExplode(), fetcher: (id) async {
-      throw FormatException('invalid');
+      throw const FormatException('invalid');
     });
 
     expect(


### PR DESCRIPTION
## Summary
- silence invalid_annotation_target warnings on Freezed classes
- update deprecated color scheme property
- remove unnecessary `toList()`
- drop redundant `mocktail` import
- prefer const constructor in tests

## Testing
- `dart format -o none lib/data/datasources/remote/chat_api_service.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f70b709083248367609c725e576f