### PR TITLE
Add local cache for music suggestions and quotes

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -38,6 +38,10 @@ import 'package:dear_flutter/data/repositories/journal_repository_impl.dart'
     as _i485;
 import 'package:dear_flutter/data/repositories/song_history_repository_impl.dart'
     as _i227;
+import 'package:dear_flutter/data/repositories/song_suggestion_cache_repository_impl.dart'
+    as _i1200;
+import 'package:dear_flutter/data/repositories/quote_cache_repository_impl.dart'
+    as _i1201;
 import 'package:dear_flutter/domain/repositories/auth_repository.dart' as _i528;
 import 'package:dear_flutter/domain/repositories/chat_repository.dart' as _i374;
 import 'package:dear_flutter/domain/repositories/home_repository.dart' as _i34;
@@ -45,6 +49,10 @@ import 'package:dear_flutter/domain/repositories/journal_repository.dart'
     as _i614;
 import 'package:dear_flutter/domain/repositories/song_history_repository.dart'
     as _i448;
+import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart'
+    as _i1202;
+import 'package:dear_flutter/domain/repositories/quote_cache_repository.dart'
+    as _i1203;
 import 'package:dear_flutter/domain/usecases/delete_account_usecase.dart'
     as _i945;
 import 'package:dear_flutter/domain/usecases/get_auth_status_usecase.dart'
@@ -111,6 +119,14 @@ extension GetItInjectableX on _i174.GetIt {
       () => registerModule.songBox,
       preResolve: true,
     );
+    await gh.lazySingletonAsync<_i979.Box<Map<dynamic, dynamic>>>(
+      () => registerModule.suggestionBox,
+      preResolve: true,
+    );
+    await gh.lazySingletonAsync<_i979.Box<Map<dynamic, dynamic>>>(
+      () => registerModule.quoteBox,
+      preResolve: true,
+    );
     gh.lazySingleton<_i578.YoutubeExplode>(
       () => registerModule.youtubeExplode(),
     );
@@ -138,6 +154,16 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i448.SongHistoryRepository>(
       () => _i227.SongHistoryRepositoryImpl(
+        gh<_i979.Box<Map<dynamic, dynamic>>>(),
+      ),
+    );
+    gh.lazySingleton<_i1202.SongSuggestionCacheRepository>(
+      () => _i1200.SongSuggestionCacheRepositoryImpl(
+        gh<_i979.Box<Map<dynamic, dynamic>>>(),
+      ),
+    );
+    gh.lazySingleton<_i1203.QuoteCacheRepository>(
+      () => _i1201.QuoteCacheRepositoryImpl(
         gh<_i979.Box<Map<dynamic, dynamic>>>(),
       ),
     );
@@ -208,6 +234,7 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i500.QuoteUpdateService(
         gh<_i104.HomeApiService>(),
         gh<_i448.NotificationService>(),
+        gh<_i1203.QuoteCacheRepository>(),
       ),
     );
     gh.lazySingleton<_i528.AuthRepository>(
@@ -224,7 +251,10 @@ extension GetItInjectableX on _i174.GetIt {
       ),
     );
     gh.lazySingleton<_i434.MusicUpdateService>(
-      () => _i434.MusicUpdateService(gh<_i104.HomeApiService>()),
+      () => _i434.MusicUpdateService(
+        gh<_i104.HomeApiService>(),
+        gh<_i1202.SongSuggestionCacheRepository>(),
+      ),
     );
     gh.factory<_i222.GetUserProfileUseCase>(
       () => _i222.GetUserProfileUseCase(gh<_i528.AuthRepository>()),

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -56,6 +56,15 @@ Dio dio(
   @lazySingleton
   Future<Box<Map>> get songBox => Hive.openBox<Map>('song_history');
 
+  @preResolve
+  @lazySingleton
+  Future<Box<Map>> get suggestionBox =>
+      Hive.openBox<Map>('song_suggestions');
+
+  @preResolve
+  @lazySingleton
+  Future<Box<Map>> get quoteBox => Hive.openBox<Map>('motivational_quotes');
+
   // --- AUDIO ---
   @lazySingleton
   YoutubeExplode youtubeExplode() => YoutubeExplode();

--- a/lib/data/repositories/quote_cache_repository_impl.dart
+++ b/lib/data/repositories/quote_cache_repository_impl.dart
@@ -1,0 +1,22 @@
+import 'package:hive/hive.dart';
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/repositories/quote_cache_repository.dart';
+
+@LazySingleton(as: QuoteCacheRepository)
+class QuoteCacheRepositoryImpl implements QuoteCacheRepository {
+  final Box<Map> _box;
+
+  QuoteCacheRepositoryImpl(this._box);
+
+  @override
+  Future<void> saveQuote(MotivationalQuote quote) =>
+      _box.put('latest', quote.toJson());
+
+  @override
+  MotivationalQuote? getLastQuote() {
+    final data = _box.get('latest');
+    if (data == null) return null;
+    return MotivationalQuote.fromJson(Map<String, dynamic>.from(data));
+  }
+}

--- a/lib/data/repositories/song_suggestion_cache_repository_impl.dart
+++ b/lib/data/repositories/song_suggestion_cache_repository_impl.dart
@@ -1,0 +1,27 @@
+import 'package:hive/hive.dart';
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/entities/song_suggestion.dart';
+import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
+
+@LazySingleton(as: SongSuggestionCacheRepository)
+class SongSuggestionCacheRepositoryImpl implements SongSuggestionCacheRepository {
+  final Box<Map> _box;
+
+  SongSuggestionCacheRepositoryImpl(this._box);
+
+  @override
+  Future<void> saveSuggestions(List<SongSuggestion> suggestions) =>
+      _box.put('latest',
+          {'items': suggestions.map((e) => e.toJson()).toList()});
+
+  @override
+  List<SongSuggestion> getLastSuggestions() {
+    final data = _box.get('latest');
+    if (data == null) return [];
+    final items = List<Map>.from(data['items'] as List);
+    return items
+        .map((e) =>
+            SongSuggestion.fromJson(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+}

--- a/lib/domain/repositories/quote_cache_repository.dart
+++ b/lib/domain/repositories/quote_cache_repository.dart
@@ -1,0 +1,6 @@
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+
+abstract class QuoteCacheRepository {
+  Future<void> saveQuote(MotivationalQuote quote);
+  MotivationalQuote? getLastQuote();
+}

--- a/lib/domain/repositories/song_suggestion_cache_repository.dart
+++ b/lib/domain/repositories/song_suggestion_cache_repository.dart
@@ -1,0 +1,6 @@
+import 'package:dear_flutter/domain/entities/song_suggestion.dart';
+
+abstract class SongSuggestionCacheRepository {
+  Future<void> saveSuggestions(List<SongSuggestion> suggestions);
+  List<SongSuggestion> getLastSuggestions();
+}

--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -3,15 +3,17 @@ import 'dart:async';
 import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
 import 'package:dear_flutter/domain/entities/song_suggestion.dart';
 import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
 
 @LazySingleton()
 class MusicUpdateService {
   final HomeApiService _apiService;
+  final SongSuggestionCacheRepository _cacheRepository;
 
   Timer? _timer;
   List<SongSuggestion> _latest = const [];
 
-  MusicUpdateService(this._apiService);
+  MusicUpdateService(this._apiService, this._cacheRepository);
 
   void start() {
     _timer?.cancel();
@@ -19,12 +21,14 @@ class MusicUpdateService {
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
-  List<SongSuggestion> get latest => _latest;
+  List<SongSuggestion> get latest =>
+      _latest.isNotEmpty ? _latest : _cacheRepository.getLastSuggestions();
 
   Future<void> _fetch() async {
     try {
       final suggestions = await _apiService.getSuggestedMusic('Netral');
       _latest = suggestions;
+      await _cacheRepository.saveSuggestions(suggestions);
     } catch (_) {
       // ignore errors
     }

--- a/lib/services/quote_update_service.dart
+++ b/lib/services/quote_update_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
 import 'package:dear_flutter/domain/entities/motivational_quote.dart';
 import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/repositories/quote_cache_repository.dart';
 
 import 'notification_service.dart';
 
@@ -10,11 +11,16 @@ import 'notification_service.dart';
 class QuoteUpdateService {
   final HomeApiService _apiService;
   final NotificationService _notificationService;
+  final QuoteCacheRepository _cacheRepository;
 
   Timer? _timer;
   MotivationalQuote? _lastQuote;
 
-  QuoteUpdateService(this._apiService, this._notificationService);
+  QuoteUpdateService(
+      this._apiService, this._notificationService, this._cacheRepository);
+
+  MotivationalQuote? get latest =>
+      _lastQuote ?? _cacheRepository.getLastQuote();
 
   void start() {
     _timer?.cancel();
@@ -29,6 +35,7 @@ class QuoteUpdateService {
         _lastQuote = quote;
         await _notificationService.showQuoteNotification(quote);
       }
+      await _cacheRepository.saveQuote(quote);
     } catch (_) {
       // Ignore errors silently
     }


### PR DESCRIPTION
## Summary
- add Hive caches for song suggestions and motivational quotes
- store fetched data in `MusicUpdateService` and `QuoteUpdateService`
- expose cached data through new repositories
- register new boxes and repositories in dependency injection

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865023995b08324b462c661a6e8ca7a