### PR TITLE
Load cached music suggestions

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -210,7 +210,10 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i183.GetMusicSuggestionsUseCase(gh<_i34.HomeRepository>()),
     );
     gh.factory<_i119.LatestMusicCubit>(
-      () => _i119.LatestMusicCubit(gh<_i183.GetMusicSuggestionsUseCase>()),
+      () => _i119.LatestMusicCubit(
+        gh<_i183.GetMusicSuggestionsUseCase>(),
+        gh<_i1202.SongSuggestionCacheRepository>(),
+      ),
     );
     gh.lazySingleton<_i374.ChatRepository>(
       () => _i41.ChatRepositoryImpl(

--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -1,28 +1,42 @@
 import 'package:dear_flutter/domain/usecases/get_music_suggestions_usecase.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
+import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 
 @injectable
 class LatestMusicCubit extends Cubit<LatestMusicState> {
   final GetMusicSuggestionsUseCase _getMusicSuggestionsUseCase;
+  final SongSuggestionCacheRepository _cacheRepository;
 
-  LatestMusicCubit(this._getMusicSuggestionsUseCase)
-      : super(const LatestMusicState()) {
+  LatestMusicCubit(
+    this._getMusicSuggestionsUseCase,
+    this._cacheRepository,
+  ) : super(const LatestMusicState()) {
     fetchLatestMusic();
   }
 
   Future<void> fetchLatestMusic() async {
-    emit(state.copyWith(status: LatestMusicStatus.loading));
+    final cached = _cacheRepository.getLastSuggestions();
+    final hasCache = cached.isNotEmpty;
+    if (hasCache) {
+      emit(state.copyWith(
+          status: LatestMusicStatus.cached, suggestions: cached));
+    } else {
+      emit(state.copyWith(status: LatestMusicStatus.loading));
+    }
     try {
       final suggestions = await _getMusicSuggestionsUseCase('Netral');
       emit(state.copyWith(
           status: LatestMusicStatus.success, suggestions: suggestions));
+      await _cacheRepository.saveSuggestions(suggestions);
     } catch (_) {
-      emit(state.copyWith(
-        status: LatestMusicStatus.failure,
-        errorMessage: 'Gagal memuat musik.',
-      ));
+      if (!hasCache) {
+        emit(state.copyWith(
+          status: LatestMusicStatus.failure,
+          errorMessage: 'Gagal memuat musik.',
+        ));
+      }
     }
   }
 }

--- a/lib/presentation/home/cubit/latest_music_state.dart
+++ b/lib/presentation/home/cubit/latest_music_state.dart
@@ -3,7 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'latest_music_state.freezed.dart';
 
-enum LatestMusicStatus { initial, loading, success, failure }
+enum LatestMusicStatus { initial, loading, cached, success, failure }
 
 @freezed
 class LatestMusicState with _$LatestMusicState {

--- a/test/latest_music_cubit_test.dart
+++ b/test/latest_music_cubit_test.dart
@@ -1,0 +1,44 @@
+import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
+import 'package:dear_flutter/domain/usecases/get_music_suggestions_usecase.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_music_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
+import 'package:dear_flutter/domain/entities/song_suggestion.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetMusicSuggestionsUseCase extends Mock
+    implements GetMusicSuggestionsUseCase {}
+
+class _FakeCacheRepo implements SongSuggestionCacheRepository {
+  List<SongSuggestion> suggestions = const [];
+
+  @override
+  Future<void> saveSuggestions(List<SongSuggestion> suggestions) async {
+    this.suggestions = suggestions;
+  }
+
+  @override
+  List<SongSuggestion> getLastSuggestions() => suggestions;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('emits cached suggestions when api fails', () async {
+    final usecase = _MockGetMusicSuggestionsUseCase();
+    final cache = _FakeCacheRepo()
+      ..suggestions = const [SongSuggestion(title: 't', artist: 'a')];
+    when(() => usecase('Netral')).thenThrow(Exception());
+
+    final cubit = LatestMusicCubit(usecase, cache);
+    final states = <LatestMusicState>[];
+    final sub = cubit.stream.listen(states.add);
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    expect(states, hasLength(1));
+    expect(states.first.status, LatestMusicStatus.cached);
+    expect(states.first.suggestions, cache.suggestions);
+    await sub.cancel();
+  });
+}


### PR DESCRIPTION
## Summary
- show cached suggestions before network fetch
- add a `cached` status to latest music state
- inject cache repository into latest music cubit
- ensure cubit keeps cached data if API fails
- add unit test for offline scenario

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686504831254832493578bc2207312e4