### PR TITLE
Add internet permission to Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="dear_flutter"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- add INTERNET permission in AndroidManifest.xml

## Issue/Ticket
- none

## Affected Files
- `android/app/src/main/AndroidManifest.xml`

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*
- `flutter build apk` *(fails: command not found)*
- `flutter run --release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651ac2b2488324ac7022eca900b317