### PR TITLE
Add just_audio quick-start snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ final handler = getIt<AudioPlayerHandler>();
 await handler.playFromYoutubeId(track.youtubeId);
 ```
 
+Below is a minimal snippet that mirrors the quick-start example from the
+`just_audio` documentation:
+
+```dart
+final player = AudioPlayer();
+await player.setUrl('https://example.com/foo.mp3');
+await player.play();
+```
+
 The `AudioPlayerScreen` widget obtains an `AudioPlayerHandler` instance and
 triggers playback as above. Background audio is enabled in `main.dart` by
 initializing `AudioService` with an `AudioServiceConfig` that defines the


### PR DESCRIPTION
## Summary
- document basic playback example using `AudioPlayer` and `play()`

## References
- n/a

## Files
- `README.md`

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651c7976b08324b4c00ea40d87c8a5