### PR TITLE
Handle missing YouTube audio streams

### DIFF
--- a/lib/services/youtube_audio_service.dart
+++ b/lib/services/youtube_audio_service.dart
@@ -43,13 +43,20 @@ class YoutubeAudioService {
     final infos = fetcher != null
         ? await fetcher!(videoIdOrUrl)
         : await _fetch(id: videoIdOrUrl);
+    if (infos.isEmpty) {
+      throw StateError('No audio streams found for $videoIdOrUrl');
+    }
     infos.sort((a, b) => a.bitrate.compareTo(b.bitrate));
     return infos.last.url.toString();
   }
 
   Future<List<AudioInfo>> _fetch({required String id}) async {
     final manifest = await yt.videos.streamsClient.getManifest(id);
-    return manifest.audioOnly
+    final audios = manifest.audioOnly;
+    if (audios.isEmpty) {
+      return [];
+    }
+    return audios
         .map((e) => AudioInfo(e.bitrate.kiloBitsPerSecond.toInt(), e.url))
         .toList();
   }

--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -46,6 +46,15 @@ void main() {
     );
   });
 
+  test('throws when no audio streams are available', () async {
+    final service = YoutubeAudioService(YoutubeExplode(), fetcher: (id) async => []);
+
+    expect(
+      () => service.getAudioUrl('abc'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
   test('close disposes YoutubeExplode client', () {
     final fake = _FakeYoutubeExplode();
     final service = YoutubeAudioService(fake, fetcher: (id) async => []);


### PR DESCRIPTION
## Summary
- throw `StateError` when no audio streams are returned
- cover empty audio result in `youtube_audio_service_test`

## Testing
- `dart format lib/services/youtube_audio_service.dart test/youtube_audio_service_test.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865239eead8832494c6d92a53d37fec