### PR TITLE
Add rich audio player features

### DIFF
--- a/backend/app/api/v1/music.py
+++ b/backend/app/api/v1/music.py
@@ -60,9 +60,19 @@ def _process_search_results(search_results: dict) -> list[schemas.AudioTrack]:
         preview = track.get("preview_url")
         external = track.get("external_urls", {}).get("spotify")
         youtube_id = preview or external or track.get("id")
+        artists = track.get("artists", [])
+        artist_names = ", ".join(a.get("name") for a in artists if a.get("name"))
+        images = track.get("album", {}).get("images", [])
+        cover_url = images[0].get("url") if images else None
         if youtube_id and title:
             musics.append(
-                schemas.AudioTrack(id=idx, title=title, youtube_id=youtube_id)
+                schemas.AudioTrack(
+                    id=idx,
+                    title=title,
+                    youtube_id=youtube_id,
+                    artist=artist_names or None,
+                    cover_url=cover_url,
+                )
             )
 
     return musics

--- a/backend/app/schemas/audio.py
+++ b/backend/app/schemas/audio.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel, ConfigDict
 class AudioTrackBase(BaseModel):
     title: str
     youtube_id: str
+    artist: str | None = None
+    cover_url: str | None = None
 
 
 class AudioTrackCreate(AudioTrackBase):

--- a/backend/tests/test_home_api.py
+++ b/backend/tests/test_home_api.py
@@ -21,7 +21,15 @@ def test_home_feed_structure_and_ordering(client, monkeypatch):
 
     async def fake_recommend_music(*, mood: str, **kwargs):
         assert mood == "lofi"
-        return [AudioTrack(id=99, title="rec", youtube_id="y1")]
+        return [
+            AudioTrack(
+                id=99,
+                title="rec",
+                youtube_id="y1",
+                artist="artist",
+                cover_url="c",
+            )
+        ]
 
     async def fake_generate_keyword(self, journals):
         return "lofi"

--- a/backend/tests/test_list_endpoints.py
+++ b/backend/tests/test_list_endpoints.py
@@ -89,9 +89,13 @@ def test_music_latest_endpoint_returns_track(client):
     from app.state.music import set_latest_music
     from app.schemas.audio import AudioTrack
 
-    set_latest_music(AudioTrack(id=1, title="t", youtube_id="y"))
+    set_latest_music(
+        AudioTrack(id=1, title="t", youtube_id="y", artist="a", cover_url="c")
+    )
     client_app, _ = client
     resp = client_app.get("/api/v1/music/latest")
     assert resp.status_code == 200
     data = resp.json()
     assert data["title"] == "t"
+    assert data["artist"] == "a"
+    assert data["cover_url"] == "c"

--- a/backend/tests/test_music_api.py
+++ b/backend/tests/test_music_api.py
@@ -17,7 +17,18 @@ def test_music_endpoint_returns_list(client, monkeypatch):
 
     # Return fake Spotify search payload
     def fake_search(self, q, type="track", limit=20):
-        return {"tracks": {"items": [{"name": "Song", "id": "abc123"}]}}
+        return {
+            "tracks": {
+                "items": [
+                    {
+                        "name": "Song",
+                        "id": "abc123",
+                        "artists": [{"name": "Artist"}],
+                        "album": {"images": [{"url": "img"}]},
+                    }
+                ]
+            }
+        }
 
     # Kita tidak lagi memanggil get_song di backend, jadi mock ini bisa disederhanakan/dihapus.
     # Namun, kita biarkan untuk keamanan jika ada logika lain yang mungkin memanggilnya.
@@ -29,6 +40,8 @@ def test_music_endpoint_returns_list(client, monkeypatch):
     data = resp.json()
     assert isinstance(data, list)
     assert data[0]["youtube_id"] == "abc123"
+    assert data[0]["artist"] == "Artist"
+    assert data[0]["cover_url"] == "img"
 
 
 @pytest.mark.asyncio

--- a/lib/domain/entities/audio_track.dart
+++ b/lib/domain/entities/audio_track.dart
@@ -10,6 +10,9 @@ class AudioTrack with _$AudioTrack {
     required String title,
     @JsonKey(name: 'youtube_id') // ignore: invalid_annotation_target
     required String youtubeId,
+    String? artist,
+    @JsonKey(name: 'cover_url') // ignore: invalid_annotation_target
+    String? coverUrl,
   }) = _AudioTrack;
 
   factory AudioTrack.fromJson(Map<String, dynamic> json) => _$AudioTrackFromJson(json);

--- a/lib/presentation/home/screens/audio_player_screen.dart
+++ b/lib/presentation/home/screens/audio_player_screen.dart
@@ -18,7 +18,13 @@ class AudioPlayerScreen extends StatefulWidget {
 class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
   late final AudioPlayerHandler _handler;
   late final StreamSubscription<PlaybackState> _sub;
+  late final StreamSubscription<Duration> _posSub;
+  late final StreamSubscription<Duration> _bufSub;
+  late final StreamSubscription<Duration?> _durSub;
   bool _isPlaying = false;
+  Duration _position = Duration.zero;
+  Duration _buffered = Duration.zero;
+  Duration _duration = Duration.zero;
 
   @override
   void initState() {
@@ -27,11 +33,25 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
     _sub = _handler.playbackState.listen((state) {
       setState(() => _isPlaying = state.playing);
     });
+    _posSub = _handler.positionStream.listen((d) {
+      setState(() => _position = d);
+    });
+    _bufSub = _handler.bufferedPositionStream.listen((d) {
+      setState(() => _buffered = d);
+    });
+    _durSub = _handler.durationStream.listen((d) {
+      if (d != null) {
+        setState(() => _duration = d);
+      }
+    });
   }
 
   @override
   void dispose() {
     _sub.cancel();
+    _posSub.cancel();
+    _bufSub.cancel();
+    _durSub.cancel();
     super.dispose();
   }
 
@@ -44,15 +64,59 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
     }
   }
 
+  Future<void> _seek(double value) async {
+    await _handler.seek(Duration(milliseconds: value.round()));
+  }
+
   @override
   Widget build(BuildContext context) {
+    final max = _duration.inMilliseconds.toDouble();
+    final value = _position.inMilliseconds.clamp(0, max).toDouble();
+    final buffer =
+        max == 0 ? 0.0 : _buffered.inMilliseconds.toDouble() / max;
     return Scaffold(
       appBar: AppBar(title: Text(widget.track.title)),
-      body: Center(
-        child: IconButton(
-          iconSize: 64,
-          icon: Icon(_isPlaying ? Icons.pause : Icons.play_arrow),
-          onPressed: _toggle,
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (widget.track.coverUrl != null)
+              ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: Image.network(
+                  widget.track.coverUrl!,
+                  height: 250,
+                  width: 250,
+                  fit: BoxFit.cover,
+                ),
+              )
+            else
+              Container(
+                height: 250,
+                width: 250,
+                color: Colors.grey,
+              ),
+            const SizedBox(height: 16),
+            Text(widget.track.title,
+                style: Theme.of(context).textTheme.titleLarge),
+            if (widget.track.artist != null)
+              Text(widget.track.artist!),
+            const SizedBox(height: 24),
+            Slider(
+              min: 0,
+              max: max > 0 ? max : 1,
+              value: value,
+              onChanged: (v) => _seek(v),
+            ),
+            LinearProgressIndicator(value: buffer),
+            const SizedBox(height: 24),
+            IconButton(
+              iconSize: 64,
+              icon: Icon(_isPlaying ? Icons.pause : Icons.play_arrow),
+              onPressed: _toggle,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -96,12 +96,14 @@ class _MusicCard extends StatelessWidget {
         subtitle: Text(suggestion.artist),
         onTap: () async {
           final service = getIt<YoutubeSearchService>();
-          final id =
-              await service.searchId('${suggestion.title} ${suggestion.artist}');
+          final result =
+              await service.search('${suggestion.title} ${suggestion.artist}');
           final track = AudioTrack(
             id: 0,
             title: suggestion.title,
-            youtubeId: id,
+            youtubeId: result.id,
+            artist: suggestion.artist,
+            coverUrl: result.thumbnailUrl,
           );
           if (context.mounted) {
             context.go('/audio', extra: track);

--- a/lib/services/audio_player_handler.dart
+++ b/lib/services/audio_player_handler.dart
@@ -18,6 +18,10 @@ class AudioPlayerHandler extends BaseAudioHandler {
   final AudioPlayer _player;
   String? _currentId;
 
+  Stream<Duration> get positionStream => _player.positionStream;
+  Stream<Duration> get bufferedPositionStream => _player.bufferedPositionStream;
+  Stream<Duration?> get durationStream => _player.durationStream;
+
   Future<void> _broadcastState(PlayerState state) async {
     playbackState.add(
       PlaybackState(
@@ -74,6 +78,8 @@ class AudioPlayerHandler extends BaseAudioHandler {
 
   @override
   Future<void> pause() => _player.pause();
+
+  Future<void> seek(Duration position) => _player.seek(position);
 
   @override
   Future<void> stop() async {

--- a/lib/services/youtube_search_service.dart
+++ b/lib/services/youtube_search_service.dart
@@ -1,20 +1,28 @@
 import 'package:injectable/injectable.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
-/// Service that searches YouTube and returns the first video id for a query.
+/// Service that searches YouTube and returns the first result.
 @lazySingleton
 class YoutubeSearchService {
   YoutubeSearchService(this._yt);
 
   final YoutubeExplode _yt;
 
-  /// Returns the video id of the first search result for [query].
-  Future<String> searchId(String query) async {
+  /// Returns the first result for [query] including id and thumbnail.
+  Future<YoutubeSearchResult> search(String query) async {
     final results = await _yt.search.search(query);
     final first = await results.first;
-    return first.id.value;
+    return YoutubeSearchResult(first.id.value, first.thumbnails.highResUrl);
   }
 
   /// Dispose the underlying [YoutubeExplode] client.
   void close() => _yt.close();
+}
+
+/// Simple data holder for a YouTube search result.
+class YoutubeSearchResult {
+  YoutubeSearchResult(this.id, this.thumbnailUrl);
+
+  final String id;
+  final String thumbnailUrl;
 }

--- a/test/audio_player_screen_test.dart
+++ b/test/audio_player_screen_test.dart
@@ -57,7 +57,13 @@ void main() {
     getIt.registerSingleton<AudioPlayerHandler>(handler);
     getIt.registerSingleton<SongHistoryRepository>(repo);
 
-    const track = AudioTrack(id: 1, title: 't', youtubeId: 'id');
+    const track = AudioTrack(
+      id: 1,
+      title: 't',
+      youtubeId: 'id',
+      artist: 'a',
+      coverUrl: 'c',
+    );
 
     await tester.pumpWidget(const MaterialApp(home: AudioPlayerScreen(track: track)));
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -41,7 +41,9 @@ void main() {
     getIt.reset();
     getIt.registerFactory<LatestMusicCubit>(() => _FakeLatestMusicCubit());
     final search = _MockSearchService();
-    when(() => search.searchId(any())).thenAnswer((_) async => 'id');
+    when(() => search.search(any())).thenAnswer(
+      (_) async => YoutubeSearchResult('id', 'thumb'),
+    );
     getIt.registerSingleton<YoutubeSearchService>(search);
   });
 


### PR DESCRIPTION
## Summary
- extend AudioTrack schema with artist and cover metadata
- expose metadata in `music` API results
- allow `YoutubeSearchService` to return video id and thumbnail
- include artist and cover data in home screen search
- enhance `AudioPlayerScreen` with progress and cover art
- expose position and seek functionality in `AudioPlayerHandler`
- update tests for new schema

## Testing
- `black backend/app backend/tests -q`
- `ruff check backend/app backend/tests`
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653676c4e883248c7a7d816f59996d