### PR TITLE
Improve Youtube audio fallback

### DIFF
--- a/lib/services/youtube_audio_service.dart
+++ b/lib/services/youtube_audio_service.dart
@@ -65,10 +65,21 @@ class YoutubeAudioService {
     if (audios.isEmpty) {
       return [];
     }
-    return audios
-        .where((e) => e.bitrate.kiloBitsPerSecond <= maxBitrateKbps)
-        .map((e) => AudioInfo(e.bitrate.kiloBitsPerSecond.toInt(), e.url))
-        .toList();
+    AudioOnlyStreamInfo chosen;
+    try {
+      chosen = audios.firstWhere((e) => e.tag == 140);
+    } on StateError {
+      final within =
+          audios.where((e) => e.bitrate.kiloBitsPerSecond <= maxBitrateKbps);
+      if (within.isNotEmpty) {
+        chosen = within.sortByBitrate().first;
+      } else {
+        chosen = audios.sortByBitrate().last;
+      }
+    }
+    return [
+      AudioInfo(chosen.bitrate.kiloBitsPerSecond.toInt(), chosen.url)
+    ];
   }
 
   /// Closes the underlying [YoutubeExplode] client and frees resources.

--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -1,5 +1,7 @@
 import 'package:dear_flutter/services/youtube_audio_service.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:http_parser/http_parser.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
 class _FakeYoutubeExplode extends YoutubeExplode {
@@ -10,6 +12,70 @@ class _FakeYoutubeExplode extends YoutubeExplode {
     closed = true;
     super.close();
   }
+}
+
+class _MockYoutubeExplode extends Mock implements YoutubeExplode {}
+
+class _MockVideoClient extends Mock implements VideoClient {}
+
+class _MockStreamClient extends Mock implements StreamClient {}
+
+class _FakeAudioOnlyStreamInfo implements AudioOnlyStreamInfo {
+  @override
+  final VideoId videoId;
+
+  @override
+  final int tag;
+
+  @override
+  final Uri url;
+
+  @override
+  final StreamContainer container;
+
+  @override
+  final FileSize size;
+
+  @override
+  final Bitrate bitrate;
+
+  @override
+  final String audioCodec;
+
+  @override
+  final MediaType codec;
+
+  @override
+  final List<Fragment> fragments;
+
+  @override
+  final String qualityLabel;
+
+  @override
+  final AudioTrack? audioTrack;
+
+  _FakeAudioOnlyStreamInfo({
+    required this.videoId,
+    required this.tag,
+    required this.url,
+    required this.bitrate,
+    this.container = StreamContainer.mp4,
+    this.size = const FileSize(0),
+    this.audioCodec = 'aac',
+    this.qualityLabel = '',
+    this.fragments = const [],
+    this.codec = const MediaType('audio', 'mp4'),
+    this.audioTrack,
+  });
+
+  @override
+  bool get isThrottled => false;
+
+  @override
+  Map<String, dynamic> toJson() => {};
+
+  @override
+  String toString() => 'FakeAudio($tag, ${bitrate.kiloBitsPerSecond})';
 }
 
 void main() {
@@ -62,5 +128,90 @@ void main() {
     service.close();
 
     expect(fake.closed, isTrue);
+  });
+
+  group('_fetch fallback', () {
+    late _MockYoutubeExplode yt;
+    late _MockVideoClient videos;
+    late _MockStreamClient streams;
+
+    setUp(() {
+      yt = _MockYoutubeExplode();
+      videos = _MockVideoClient();
+      streams = _MockStreamClient();
+      when(() => yt.videos).thenReturn(videos);
+      when(() => videos.streamsClient).thenReturn(streams);
+    });
+
+    test('prefers itag 140 when available', () async {
+      final manifest = StreamManifest([
+        _FakeAudioOnlyStreamInfo(
+          videoId: VideoId('id'),
+          tag: 140,
+          url: Uri.parse('u140'),
+          bitrate: const Bitrate(128000),
+        ),
+        _FakeAudioOnlyStreamInfo(
+          videoId: VideoId('id'),
+          tag: 141,
+          url: Uri.parse('u141'),
+          bitrate: const Bitrate(150000),
+        ),
+      ]);
+      when(() => streams.getManifest(any())).thenAnswer((_) async => manifest);
+
+      final service = YoutubeAudioService(yt);
+      final url = await service.getAudioUrl('id');
+
+      expect(url, 'u140');
+    });
+
+    test('falls back to highest bitrate below max', () async {
+      final manifest = StreamManifest([
+        _FakeAudioOnlyStreamInfo(
+          videoId: VideoId('id'),
+          tag: 141,
+          url: Uri.parse('u150'),
+          bitrate: const Bitrate(150000),
+        ),
+        _FakeAudioOnlyStreamInfo(
+          videoId: VideoId('id'),
+          tag: 142,
+          url: Uri.parse('u200'),
+          bitrate: const Bitrate(200000),
+        ),
+      ]);
+      when(() => streams.getManifest(any())).thenAnswer((_) async => manifest);
+
+      final service = YoutubeAudioService(yt);
+      final url = await service.getAudioUrl('id');
+
+      expect(url, 'u150');
+    });
+
+    test('returns lowest bitrate when none under max', () async {
+      final manifest = StreamManifest([
+        _FakeAudioOnlyStreamInfo(
+          videoId: VideoId('id'),
+          tag: 141,
+          url: Uri.parse('u170'),
+          bitrate: const Bitrate(170000),
+        ),
+        _FakeAudioOnlyStreamInfo(
+          videoId: VideoId('id'),
+          tag: 142,
+          url: Uri.parse('u200'),
+          bitrate: const Bitrate(200000),
+        ),
+      ]);
+      when(() => streams.getManifest(any())).thenAnswer((_) async => manifest);
+
+      final service = YoutubeAudioService(yt);
+
+      expect(
+        () => service.getAudioUrl('id'),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- prefer itag `140` when fetching Youtube audio streams
- fall back to best allowed or lowest bitrate
- test the fallback logic for Youtube audio

## Issues
- None specified

## Files Affected
- `lib/services/youtube_audio_service.dart`
- `test/youtube_audio_service_test.dart`

## Testing
- `dart format lib/services/youtube_audio_service.dart` *(fails: command not found)*
- `dart format test/youtube_audio_service_test.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654d015ff08324a548c89384fc09a7