### PR TITLE
Add profiling audit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ Contributions are welcome! Please open issues or pull requests on GitHub. Make s
 
 - Use the commit message style `<type>(<scope>): <description>` as outlined in `AGENTS.md`. For example: `fix(ui): resolve newline issues`.
 
+## Profiling
+
+See [docs/PROFILING.md](docs/PROFILING.md) for details on API and audio performance.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -1,0 +1,22 @@
+# Profiling Audit
+
+This document summarizes the audit of API calls and audio decoding tasks throughout the Flutter frontend and backend services. The goal is to ensure that no heavy work is executed directly inside `build()` or `initState()` methods.
+
+## Methodology
+
+- Searched the `lib/` directory for network requests, audio decoding and CPU intensive loops.
+- Inspected widgets for `initState()` or `build()` implementations performing heavy work.
+- Verified services responsible for audio playback and data fetching use asynchronous `Future` APIs.
+
+## Findings
+
+- All API interactions are encapsulated in Cubits or service classes and triggered asynchronously via `Future` methods. Widgets themselves only await lightweight calls.
+- The audio player uses `audio_service` and `just_audio` which internally decode streams asynchronously. The `AudioPlayerScreen` does not decode audio in `build()` or `initState()`.
+- The `YoutubeAudioService` resolves stream URLs using asynchronous calls to `YoutubeExplode`. No synchronous parsing or heavy computation was found in the UI layer.
+- No calls to `compute()` or isolates were necessary given the absence of blocking operations in the UI thread.
+
+## Recommendations
+
+- Continue using `Future` based APIs for network and audio tasks. If future features introduce CPU heavy processing (e.g. waveform analysis), wrap it in `compute()` or a dedicated isolate.
+- Profile new features using `flutter run --profile` to ensure frame times remain under 16ms on target devices.
+


### PR DESCRIPTION
## Summary
- document API and audio performance audit
- reference audit in README

## Testing
- `black backend`
- `ruff check backend`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `flutter test` *(fails: flutter: command not found)*
- `dart format .` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654fbc3c5c832495073556d8ef77bc