### PR TITLE
Prevent repeated Home screen fetches

### DIFF
--- a/lib/presentation/home/cubit/home_cubit.dart
+++ b/lib/presentation/home/cubit/home_cubit.dart
@@ -12,12 +12,22 @@ class HomeCubit extends Cubit<HomeState> {
   final GetJournalsUseCase _getJournalsUseCase;
   final SyncJournalsUseCase _syncJournalsUseCase;
   StreamSubscription? _journalSubscription;
+  bool _initialized = false;
 
   HomeCubit(this._getJournalsUseCase, this._syncJournalsUseCase)
       : super(const HomeState()) {
+    initialize();
+  }
+
+  void initialize() {
+    if (_initialized) {
+      debugPrint('HomeCubit already initialized');
+      return;
+    }
+    _initialized = true;
     // Jalankan pemantauan dan sinkronisasi jurnal saat cubit diinisialisasi
     watchJournals();
-    syncJournals(); // <-- Sudah tidak dikomentari
+    syncJournals();
   }
 
   Future<void> syncJournals() async {

--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -8,6 +8,7 @@ import 'package:injectable/injectable.dart';
 class LatestMusicCubit extends Cubit<LatestMusicState> {
   final GetMusicSuggestionsUseCase _getMusicSuggestionsUseCase;
   final SongSuggestionCacheRepository _cacheRepository;
+  bool _hasFetched = false;
 
   LatestMusicCubit(
     this._getMusicSuggestionsUseCase,
@@ -17,6 +18,12 @@ class LatestMusicCubit extends Cubit<LatestMusicState> {
   }
 
   Future<void> fetchLatestMusic() async {
+    if (_hasFetched) {
+      debugPrint('fetchLatestMusic skipped: already fetched');
+      return;
+    }
+    _hasFetched = true;
+
     final cached = _cacheRepository.getLastSuggestions();
     final hasCache = cached.isNotEmpty;
     if (hasCache) {

--- a/test/home_cubit_init_test.dart
+++ b/test/home_cubit_init_test.dart
@@ -1,0 +1,25 @@
+import 'package:dear_flutter/domain/usecases/get_journals_usecase.dart';
+import 'package:dear_flutter/domain/usecases/sync_journals_usecase.dart';
+import 'package:dear_flutter/presentation/home/cubit/home_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGetJournalsUseCase extends Mock implements GetJournalsUseCase {}
+
+class _MockSyncJournalsUseCase extends Mock implements SyncJournalsUseCase {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('initialize only triggers sync once', () async {
+    final get = _MockGetJournalsUseCase();
+    final sync = _MockSyncJournalsUseCase();
+    when(() => get()).thenAnswer((_) => const Stream.empty());
+    when(() => sync()).thenAnswer((_) async {});
+
+    final cubit = HomeCubit(get, sync);
+    cubit.initialize();
+
+    verify(() => sync()).called(1);
+  });
+}

--- a/test/latest_music_cubit_test.dart
+++ b/test/latest_music_cubit_test.dart
@@ -41,4 +41,15 @@ void main() {
     expect(states.first.suggestions, cache.suggestions);
     await sub.cancel();
   });
+
+  test('fetchLatestMusic only calls api once', () async {
+    final usecase = _MockGetMusicSuggestionsUseCase();
+    final cache = _FakeCacheRepo();
+    when(() => usecase('Netral')).thenAnswer((_) async => []);
+
+    final cubit = LatestMusicCubit(usecase, cache);
+    await cubit.fetchLatestMusic();
+
+    verify(() => usecase('Netral')).called(1);
+  });
 }


### PR DESCRIPTION
## Summary
- guard HomeCubit initialization to avoid duplicate sync
- prevent LatestMusicCubit from fetching more than once
- test cubits only call APIs once

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686551338ccc83249bc45ac661dfc659