### PR TITLE
Resolve analyzer errors in tests

### DIFF
--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -1,6 +1,7 @@
 import 'package:dear_flutter/domain/usecases/get_music_suggestions_usecase.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
 import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dev_dependencies:
   json_serializable: ^6.7.1              # Codegen untuk JSON
   drift_dev: ^2.14.0                     # Codegen untuk ORM Drift
   mocktail: ^1.0.1                       # Untuk mocking di unit test
+  http_parser: ^4.0.0
 
 flutter:
   uses-material-design: true

--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:http_parser/http_parser.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
+import 'package:youtube_explode_dart/src/reverse_engineering/models/fragment.dart';
+import 'package:youtube_explode_dart/src/videos/streams/models/audio_track.dart';
 
 class _FakeYoutubeExplode extends YoutubeExplode {
   bool closed = false;
@@ -64,7 +66,7 @@ class _FakeAudioOnlyStreamInfo implements AudioOnlyStreamInfo {
     this.audioCodec = 'aac',
     this.qualityLabel = '',
     this.fragments = const [],
-    this.codec = const MediaType('audio', 'mp4'),
+    this.codec = MediaType('audio', 'mp4'),
     this.audioTrack,
   });
 


### PR DESCRIPTION
## Summary
- fix missing import for debugPrint in `LatestMusicCubit`
- update test imports to internal youtube_explode models
- drop const MediaType default in test fake
- add `http_parser` dev dependency

## Testing
- `dart format` *(fails: dart not found)*
- `dart analyze` *(fails: dart not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_686554bfda0c8324a8eed0fef54135ee