### PR TITLE
Fix non-constant default value in test

### DIFF
--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -66,9 +66,9 @@ class _FakeAudioOnlyStreamInfo implements AudioOnlyStreamInfo {
     this.audioCodec = 'aac',
     this.qualityLabel = '',
     this.fragments = const [],
-    this.codec = MediaType('audio', 'mp4'),
+    MediaType? codec,
     this.audioTrack,
-  });
+  }) : codec = codec ?? MediaType('audio', 'mp4');
 
   @override
   bool get isThrottled => false;


### PR DESCRIPTION
## Summary
- fix default parameter in `_FakeAudioOnlyStreamInfo`

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865577ef6e48324aa5a009bc8ff18cb