### PR TITLE
Update home screen music flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ Future<void> main() async {
   // Inisialisasi dependency injection (getIt, dll.)
   await configureDependencies();
   final handler = await AudioService.init(
-    builder: () => AudioPlayerHandler(getIt<YoutubeAudioService>()),
+    builder: getIt<AudioPlayerHandler>,
     config: const AudioServiceConfig(
       androidNotificationChannelId: 'com.example.dear.audio',
       androidNotificationChannelName: 'Audio Playback',
@@ -28,7 +28,6 @@ Future<void> main() async {
   }
   await getIt<NotificationService>().init();
   getIt<QuoteUpdateService>().start();
-  getIt<MusicUpdateService>().start();
 
   runApp(const MyApp());
 }

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -27,9 +27,14 @@ class HomeScreen extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Beranda'),
         ),
-        body: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
+        body: RefreshIndicator(
+          onRefresh: () async {
+            await context.read<LatestMusicCubit>().fetchLatestMusic();
+            await context.read<LatestQuoteCubit>().fetchLatestQuote();
+          },
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
             BlocBuilder<LatestQuoteCubit, LatestQuoteState>(
               builder: (context, state) {
                 if (state.status == LatestQuoteStatus.loading) {
@@ -61,6 +66,7 @@ class HomeScreen extends StatelessWidget {
                 if (state.suggestions.isEmpty) {
                   return const SizedBox.shrink();
                 }
+                final suggestion = state.suggestions.first;
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -69,8 +75,7 @@ class HomeScreen extends StatelessWidget {
                       style: Theme.of(context).textTheme.headlineSmall,
                     ),
                     const SizedBox(height: 16),
-                    ...state.suggestions
-                        .map((s) => _MusicCard(suggestion: s)),
+                    _MusicCard(suggestion: suggestion),
                   ],
                 );
               },


### PR DESCRIPTION
## Summary
- ensure single global `AudioPlayerHandler`
- fetch music suggestions only on pull-to-refresh
- show a single song suggestion on Home screen
- adjust tests for new cubit behaviour

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655e79f9f88324bba9721758fc25d7