### PR TITLE
Fix home screen refresh context usage

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -29,8 +29,10 @@ class HomeScreen extends StatelessWidget {
         ),
         body: RefreshIndicator(
           onRefresh: () async {
-            await context.read<LatestMusicCubit>().fetchLatestMusic();
-            await context.read<LatestQuoteCubit>().fetchLatestQuote();
+            final musicCubit = context.read<LatestMusicCubit>();
+            final quoteCubit = context.read<LatestQuoteCubit>();
+            await musicCubit.fetchLatestMusic();
+            await quoteCubit.fetchLatestQuote();
           },
           child: ListView(
             padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## Summary
- capture cubits before awaiting in `onRefresh`

## Testing
- `dart format lib/presentation/home/screens/home_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686561d4b3588324a8a8fcf81352d979