### PR TITLE
Fix home screen build errors

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -12,6 +12,8 @@ import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
 import 'package:dear_flutter/services/audio_player_handler.dart';
 import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
 import 'package:go_router/go_router.dart';
+import 'dart:async';
+import 'package:audio_service/audio_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shimmer/shimmer.dart';
@@ -112,7 +114,7 @@ class _HomeScreenState extends State<HomeScreen> {
                   children: [
                     const _QuoteSection(),
                     const SizedBox(height: 24),
-                    const _MusicSection(),
+                    _MusicSection(onPlay: _playSuggestion),
                   ],
                 ),
               ),
@@ -174,7 +176,9 @@ class _ShimmerQuoteCard extends StatelessWidget {
 
 // Widget for displaying music cards
 class _MusicSection extends StatelessWidget {
-  const _MusicSection();
+  const _MusicSection({required this.onPlay});
+
+  final Future<void> Function(SongSuggestion) onPlay;
 
   @override
   Widget build(BuildContext context) {
@@ -204,7 +208,7 @@ class _MusicSection extends StatelessWidget {
             const SizedBox(height: 16),
             _MusicCard(
               suggestion: suggestion,
-              onTap: () => _playSuggestion(suggestion),
+              onTap: () => onPlay(suggestion),
             ),
           ],
         );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   json_annotation: ^4.9.0                # Untuk serialisasi model
   url_launcher: ^6.2.6                  # Membuka tautan eksternal
   share_plus: ^7.2.1                    # Berbagi konten
+  shimmer: ^3.0.0                       # Efek loading shimmer
   webview_flutter: ^4.4.1              # Menampilkan halaman web dalam aplikasi
   just_audio: ^0.10.4                   # Pemutar audio lanjutan
   audio_service: ^0.18.18               # Layanan audio latar belakang


### PR DESCRIPTION
## Summary
- resolve imports for `StreamSubscription` and `PlaybackState`
- allow playing song suggestions from music section
- add `shimmer` dependency for loading effects

## Issue
- closes #1 (assumed issue for build errors)

## Affected Files
- `lib/presentation/home/screens/home_screen.dart`
- `pubspec.yaml`

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865781549c08324960d504d397cb26c