### PR TITLE
Add audio buffering docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Contributions are welcome! Please open issues or pull requests on GitHub. Make s
 ## Profiling
 
 See [docs/PROFILING.md](docs/PROFILING.md) for details on API and audio performance.
+For information on Android buffering logs and tuning ExoPlayer, see
+[docs/AUDIO_BUFFERING.md](docs/AUDIO_BUFFERING.md).
 
 ## License
 

--- a/docs/AUDIO_BUFFERING.md
+++ b/docs/AUDIO_BUFFERING.md
@@ -1,0 +1,33 @@
+# Android Audio Buffering
+
+This document explains the buffering messages printed by Android when playing audio and how `just_audio` configures ExoPlayer.
+
+## CCodecConfig and CCodecBufferChannel
+
+`CCodecConfig` and `CCodecBufferChannel` messages originate from Android's `MediaCodec` stack. They appear in `adb logcat` when a codec is created or buffers are queued.
+
+- **`CCodecConfig`** – describes the codec parameters such as sample rate and channel count. It is logged during decoder setup and is informational rather than an error.
+- **`CCodecBufferChannel`** – indicates input or output buffer activity. These logs typically show buffer sizes or that the decoder is ready. They are normally harmless and can be ignored unless accompanied by an error.
+
+## just_audio and ExoPlayer
+
+On Android, the `just_audio` package wraps ExoPlayer. ExoPlayer allocates memory for decoding and buffering audio streams. With default settings the player keeps roughly 15–50 seconds of audio data in memory using a few megabytes per instance. Only the buffered region is stored; the remainder of the track is streamed from the network or file system on demand.
+
+## Adjusting buffer sizes
+
+Buffering parameters can be tuned when constructing the `AudioPlayer`:
+
+```dart
+final player = AudioPlayer(
+  audioLoadConfiguration: AudioLoadConfiguration(
+    androidLoadControl: AndroidLoadControl(
+      minBufferDuration: const Duration(seconds: 10),
+      maxBufferDuration: const Duration(seconds: 60),
+      bufferForPlaybackDuration: const Duration(seconds: 1),
+      bufferForPlaybackAfterRebufferDuration: const Duration(seconds: 5),
+    ),
+  ),
+);
+```
+
+You may also implement your own `AndroidLoadControl` to override ExoPlayer's `DefaultLoadControl` and specify a `targetBufferBytes` value. Increasing these values increases memory usage but can reduce stalling on slower connections.


### PR DESCRIPTION
## Summary
- explain Android buffer messages and ExoPlayer memory usage
- document how to tune buffer sizes
- link from README to AUDIO_BUFFERING.md

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666aac944883249d43438b7f9bd964