### PR TITLE
Add optional load config to AudioPlayerHandler

### DIFF
--- a/docs/AUDIO_BUFFERING.md
+++ b/docs/AUDIO_BUFFERING.md
@@ -31,3 +31,19 @@ final player = AudioPlayer(
 ```
 
 You may also implement your own `AndroidLoadControl` to override ExoPlayer's `DefaultLoadControl` and specify a `targetBufferBytes` value. Increasing these values increases memory usage but can reduce stalling on slower connections.
+
+The same configuration can be supplied when creating `AudioPlayerHandler` so the underlying player uses those buffer sizes:
+
+```dart
+final handler = AudioPlayerHandler(
+  youtubeService,
+  loadConfiguration: AudioLoadConfiguration(
+    androidLoadControl: AndroidLoadControl(
+      minBufferDuration: const Duration(seconds: 10),
+      maxBufferDuration: const Duration(seconds: 60),
+      bufferForPlaybackDuration: const Duration(seconds: 1),
+      bufferForPlaybackAfterRebufferDuration: const Duration(seconds: 5),
+    ),
+  ),
+);
+```

--- a/lib/services/audio_player_handler.dart
+++ b/lib/services/audio_player_handler.dart
@@ -10,8 +10,17 @@ import 'youtube_audio_service.dart';
 /// controls via `audio_service`.
 @LazySingleton()
 class AudioPlayerHandler extends BaseAudioHandler {
-  AudioPlayerHandler(this._youtube, {AudioPlayer? player})
-      : _player = player ?? AudioPlayer() {
+  /// Creates a handler managing [AudioPlayer] playback.
+  ///
+  /// The optional [player] can be supplied for testing. When omitted, a new
+  /// [AudioPlayer] is created. To customize buffering behavior provide a
+  /// [loadConfiguration], otherwise the default configuration is used.
+  AudioPlayerHandler(
+    this._youtube, {
+    AudioPlayer? player,
+    AudioLoadConfiguration? loadConfiguration,
+  }) : _player =
+            player ?? AudioPlayer(audioLoadConfiguration: loadConfiguration ?? const AudioLoadConfiguration()) {
     _player.playerStateStream.listen(_broadcastState);
   }
 


### PR DESCRIPTION
## Summary
- allow `AudioPlayerHandler` to pass an `AudioLoadConfiguration` to `AudioPlayer`
- document buffering configuration usage

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666e7436508324be122fd1bd342bca