### PR TITLE
Fix duplicate quote requests

### DIFF
--- a/lib/presentation/home/cubit/latest_quote_cubit.dart
+++ b/lib/presentation/home/cubit/latest_quote_cubit.dart
@@ -1,40 +1,29 @@
-import 'package:dear_flutter/domain/repositories/quote_cache_repository.dart';
-import 'package:dear_flutter/domain/usecases/get_latest_quote_usecase.dart';
+import 'package:dear_flutter/services/quote_update_service.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 
 @injectable
 class LatestQuoteCubit extends Cubit<LatestQuoteState> {
-  final GetLatestQuoteUseCase _getLatestQuoteUseCase;
-  final QuoteCacheRepository _cacheRepository;
+  final QuoteUpdateService _updateService;
 
-  LatestQuoteCubit(
-    this._getLatestQuoteUseCase,
-    this._cacheRepository,
-  ) : super(const LatestQuoteState()) {
-    fetchLatestQuote();
+  LatestQuoteCubit(this._updateService) : super(const LatestQuoteState()) {
+    final cached = _updateService.latest;
+    if (cached != null) {
+      emit(state.copyWith(status: LatestQuoteStatus.cached, quote: cached));
+    }
   }
 
   Future<void> fetchLatestQuote() async {
-    final cached = _cacheRepository.getLastQuote();
-    final hasCache = cached != null;
-    if (hasCache) {
-      emit(state.copyWith(status: LatestQuoteStatus.cached, quote: cached));
-    } else {
-      emit(state.copyWith(status: LatestQuoteStatus.loading));
-    }
-    try {
-      final quote = await _getLatestQuoteUseCase();
+    emit(state.copyWith(status: LatestQuoteStatus.loading));
+    final quote = await _updateService.refresh();
+    if (quote != null) {
       emit(state.copyWith(status: LatestQuoteStatus.success, quote: quote));
-      await _cacheRepository.saveQuote(quote);
-    } catch (_) {
-      if (!hasCache) {
-        emit(state.copyWith(
-          status: LatestQuoteStatus.failure,
-          errorMessage: 'Gagal memuat quote.',
-        ));
-      }
+    } else {
+      emit(state.copyWith(
+        status: LatestQuoteStatus.failure,
+        errorMessage: 'Gagal memuat quote.',
+      ));
     }
   }
 }

--- a/lib/services/quote_update_service.dart
+++ b/lib/services/quote_update_service.dart
@@ -28,7 +28,9 @@ class QuoteUpdateService {
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
-  Future<void> _fetch() async {
+  Future<MotivationalQuote?> refresh() => _fetch();
+
+  Future<MotivationalQuote?> _fetch() async {
     try {
       final quote = await _apiService.getLatestQuote();
       if (_lastQuote == null || quote.id != _lastQuote!.id) {
@@ -36,8 +38,10 @@ class QuoteUpdateService {
         await _notificationService.showQuoteNotification(quote);
       }
       await _cacheRepository.saveQuote(quote);
+      return _lastQuote;
     } catch (_) {
       // Ignore errors silently
+      return null;
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid duplicate quote requests by reusing `QuoteUpdateService`
- fetch quotes via the update service and expose `refresh`

## Testing
- `dart format lib/services/quote_update_service.dart lib/presentation/home/cubit/latest_quote_cubit.dart` *(fails: `dart` not found)*
- `dart analyze` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666f9ddef48324bd5071c7ff7354ef