### PR TITLE
Update failing unit test

### DIFF
--- a/test/latest_quote_cubit_test.dart
+++ b/test/latest_quote_cubit_test.dart
@@ -1,43 +1,23 @@
 import 'package:dear_flutter/domain/entities/motivational_quote.dart';
-import 'package:dear_flutter/domain/repositories/quote_cache_repository.dart';
-import 'package:dear_flutter/domain/usecases/get_latest_quote_usecase.dart';
+import 'package:dear_flutter/services/quote_update_service.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_quote_cubit.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class _MockGetLatestQuoteUseCase extends Mock implements GetLatestQuoteUseCase {}
-
-class _FakeCacheRepo implements QuoteCacheRepository {
-  MotivationalQuote? quote;
-
-  @override
-  Future<void> saveQuote(MotivationalQuote quote) async {
-    this.quote = quote;
-  }
-
-  @override
-  MotivationalQuote? getLastQuote() => quote;
-}
+class _MockQuoteUpdateService extends Mock implements QuoteUpdateService {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  test('emits cached quote when api fails', () async {
-    final usecase = _MockGetLatestQuoteUseCase();
-    final cache = _FakeCacheRepo()
-      ..quote = const MotivationalQuote(id: 1, text: 't', author: 'a');
-    when(() => usecase()).thenThrow(Exception());
+  test('loads cached quote on init', () async {
+    const quote = MotivationalQuote(id: 1, text: 't', author: 'a');
+    final service = _MockQuoteUpdateService();
+    when(() => service.latest).thenReturn(quote);
 
-    final cubit = LatestQuoteCubit(usecase, cache);
-    final states = <LatestQuoteState>[];
-    final sub = cubit.stream.listen(states.add);
+    final cubit = LatestQuoteCubit(service);
 
-    await Future<void>.delayed(const Duration(milliseconds: 10));
-
-    expect(states, hasLength(1));
-    expect(states.first.status, LatestQuoteStatus.cached);
-    expect(states.first.quote, cache.quote);
-    await sub.cancel();
+    expect(cubit.state.status, LatestQuoteStatus.cached);
+    expect(cubit.state.quote, quote);
   });
 }


### PR DESCRIPTION
## Summary
- update `latest_quote_cubit_test` to use `QuoteUpdateService`

## Testing
- `dart format -o none --set-exit-if-changed test/latest_quote_cubit_test.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866728f5ca083249746c4763fd8ae25