### PR TITLE
Fix analyzer warnings and missing dependency

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:dear_flutter/services/quote_update_service.dart';
 import 'package:dear_flutter/services/music_update_service.dart';
 import 'package:audio_service/audio_service.dart';
 import 'services/audio_player_handler.dart';
-import 'services/youtube_audio_service.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 Future<void> main() async {
@@ -17,7 +16,7 @@ Future<void> main() async {
   // Inisialisasi dependency injection (getIt, dll.)
   await configureDependencies();
   final handler = await AudioService.init(
-    builder: getIt<AudioPlayerHandler>,
+    builder: getIt<AudioPlayerHandler>.call,
     config: const AudioServiceConfig(
       androidNotificationChannelId: 'com.example.dear.audio',
       androidNotificationChannelName: 'Audio Playback',
@@ -28,6 +27,7 @@ Future<void> main() async {
   }
   await getIt<NotificationService>().init();
   getIt<QuoteUpdateService>().start();
+  getIt<MusicUpdateService>().start();
 
   runApp(const MyApp());
 }

--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -1,7 +1,6 @@
 import 'package:dear_flutter/domain/usecases/get_music_suggestions_usecase.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
 import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 

--- a/lib/presentation/home/screens/audio_player_screen.dart
+++ b/lib/presentation/home/screens/audio_player_screen.dart
@@ -63,22 +63,21 @@ class _AudioPlayerScreenState extends State<AudioPlayerScreen> {
       await getIt<SongHistoryRepository>().addTrack(widget.track);
       try {
         await _handler.playFromYoutubeId(widget.track.youtubeId);
+        if (!mounted) return;
       } on YoutubeExplodeException catch (_) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context)
-            ..hideCurrentSnackBar()
-            ..showSnackBar(
-              const SnackBar(content: Text('Gagal memutar audio dari YouTube')),
-            );
-        }
+        if (!mounted) return;
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            const SnackBar(content: Text('Gagal memutar audio dari YouTube')),
+          );
       } on StateError catch (_) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context)
-            ..hideCurrentSnackBar()
-            ..showSnackBar(
-              const SnackBar(content: Text('Audio tidak tersedia')), 
-            );
-        }
+        if (!mounted) return;
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            const SnackBar(content: Text('Audio tidak tersedia')),
+          );
       }
     }
   }

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -79,12 +79,13 @@ class _HomeScreenState extends State<HomeScreen> {
       // Save track to history and start playback
       await getIt<SongHistoryRepository>().addTrack(track);
       await _handler.playFromYoutubeId(track.youtubeId);
-
+      if (!mounted) return;
       setState(() {
         _currentTrack = track;
         _isPlaying = false; // Hide loading indicator
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() => _isPlaying = false); // Hide loading indicator on error
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Gagal memuat lagu. Coba lagi.')),
@@ -325,7 +326,7 @@ class _PlayerBar extends StatelessWidget {
     }
 
     return Material(
-      color: Theme.of(context).colorScheme.surfaceVariant,
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/services/audio_player_handler.dart
+++ b/lib/services/audio_player_handler.dart
@@ -102,6 +102,7 @@ class AudioPlayerHandler extends BaseAudioHandler {
   @override
   Future<void> pause() => _player.pause();
 
+  @override
   Future<void> seek(Duration position) => _player.seek(position);
 
   @override

--- a/lib/services/youtube_search_service.dart
+++ b/lib/services/youtube_search_service.dart
@@ -11,7 +11,7 @@ class YoutubeSearchService {
   /// Returns the first result for [query] including id and thumbnail.
   Future<YoutubeSearchResult> search(String query) async {
     final results = await _yt.search.search(query);
-    final first = await results.first;
+    final first = results.first;
     return YoutubeSearchResult(first.id.value, first.thumbnails.highResUrl);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dev_dependencies:
   drift_dev: ^2.14.0                     # Codegen untuk ORM Drift
   mocktail: ^1.0.1                       # Untuk mocking di unit test
   http_parser: ^4.0.0
+  rxdart: any
 
 flutter:
   uses-material-design: true

--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -61,14 +61,13 @@ class _FakeAudioOnlyStreamInfo implements AudioOnlyStreamInfo {
     required this.tag,
     required this.url,
     required this.bitrate,
-    this.container = StreamContainer.mp4,
-    this.size = const FileSize(0),
-    this.audioCodec = 'aac',
-    this.qualityLabel = '',
-    this.fragments = const [],
-    MediaType? codec,
-    this.audioTrack,
-  }) : codec = codec ?? MediaType('audio', 'mp4');
+  })  : container = StreamContainer.mp4,
+        size = const FileSize(0),
+        audioCodec = 'aac',
+        qualityLabel = '',
+        fragments = const [],
+        codec = const MediaType('audio', 'mp4'),
+        audioTrack = null;
 
   @override
   bool get isThrottled => false;


### PR DESCRIPTION
## Summary
- remove unused imports and fix analyzer warnings
- add missing rxdart dev dependency
- ensure MusicUpdateService starts in main
- update color property to surfaceContainerHighest
- guard context usage across async gaps
- fix `await` on non-future and add missing override
- simplify FakeAudioOnlyStreamInfo constructor

## Testing
- `dart format .` *(fails: dart not found)*
- `dart analyze` *(fails: dart not found)*
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667407144083248e1fc518ad676bf8