### PR TITLE
Fix analyzer issues in audio service

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,7 +16,7 @@ Future<void> main() async {
   // Inisialisasi dependency injection (getIt, dll.)
   await configureDependencies();
   final handler = await AudioService.init(
-    builder: getIt<AudioPlayerHandler>.call,
+    builder: () => getIt<AudioPlayerHandler>(),
     config: const AudioServiceConfig(
       androidNotificationChannelId: 'com.example.dear.audio',
       androidNotificationChannelName: 'Audio Playback',

--- a/test/youtube_audio_service_test.dart
+++ b/test/youtube_audio_service_test.dart
@@ -66,7 +66,7 @@ class _FakeAudioOnlyStreamInfo implements AudioOnlyStreamInfo {
         audioCodec = 'aac',
         qualityLabel = '',
         fragments = const [],
-        codec = const MediaType('audio', 'mp4'),
+        codec = MediaType('audio', 'mp4'),
         audioTrack = null;
 
   @override


### PR DESCRIPTION
## Summary
- remove invalid const from `_FakeAudioOnlyStreamInfo`
- pass builder as explicit closure in `main`

## Testing
- `dart format -o none lib/main.dart test/youtube_audio_service_test.dart` *(fails: dart not found)*
- `dart analyze` *(fails: dart not found)*
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_686677630118832496aec43593182414