### PR TITLE
Fix DI for AudioLoadConfiguration

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -122,6 +122,8 @@ extension GetItInjectableX on _i174.GetIt {
       () => registerModule.youtubeExplode(),
     );
     gh.lazySingleton<_i501.AudioPlayer>(() => registerModule.audioPlayer());
+    gh.lazySingleton<_i501.AudioLoadConfiguration>(
+        () => registerModule.audioLoadConfiguration());
     gh.lazySingleton<_i989.LoggingInterceptor>(
       () => _i989.LoggingInterceptor(),
     );

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -74,4 +74,8 @@ Dio dio(
 
   @lazySingleton
   AudioPlayer audioPlayer() => AudioPlayer();
+
+  @lazySingleton
+  AudioLoadConfiguration audioLoadConfiguration() =>
+      const AudioLoadConfiguration();
 }


### PR DESCRIPTION
## Summary
- register `AudioLoadConfiguration` in the dependency injection module
- ensure generated config references the new provider

Fixes startup failure caused by missing `AudioLoadConfiguration` in GetIt.

## Testing
- `black --check .`
- `ruff check .`
- ⚠️ `dart format` and `flutter` commands unavailable in environment

------
https://chatgpt.com/codex/tasks/task_e_68667c3fada08324a137e505f2d31c27