### PR TITLE
Handle playback completion

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -40,8 +40,16 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     _handler = getIt<AudioPlayerHandler>();
-    _playSub = _handler.playbackState.listen((state) {
-      setState(() => _isPlaying = state.playing);
+    _playSub = _handler.playbackState.listen((state) async {
+      if (state.processingState == AudioProcessingState.completed) {
+        await _handler.seek(Duration.zero);
+        setState(() {
+          _isPlaying = false;
+          _currentTrack = null;
+        });
+      } else {
+        setState(() => _isPlaying = state.playing);
+      }
     });
     _posSub = _handler.positionStream.listen((d) {
       setState(() => _position = d);


### PR DESCRIPTION
## Summary
- reset playback when a track finishes so play starts from the beginning

## Issue
- closes #9

## Testing
- `dart format .` *(fails: dart not installed)*
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866836aeea88324ad9efedf2ae0a82d