### PR TITLE
Implement music recommendation task

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -38,5 +38,11 @@ celery -A app.celery_app.celery_app worker --loglevel=info
 celery -A app.celery_app.celery_app beat --loglevel=info
 ```
 
-The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new quote based on recent journal moods. The `generate_music_recommendation_task` runs every 15 minutes and stores the latest recommended track in memory for the `/music/latest` endpoint.
+The scheduled task `generate_quote_task` runs every 15 minutes and inserts a new
+quote based on recent journal moods. `generate_music_recommendation_task` runs on
+the same schedule. It extracts a keyword from the most recent journals using
+`MusicKeywordService`, requests song suggestions via `MusicSuggestionService`,
+performs a lightweight YouTube search to resolve a `youtube_id`, and finally
+stores the resulting `AudioTrack` in memory via `set_latest_music`. The most
+recent track can be fetched from `/music/latest`.
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,3 +25,6 @@ redis
 
 # --- Testing ---
 pytest-asyncio
+
+# --- Utility ---
+youtube-search-python

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from app import models
+from app.services.music_keyword_service import MusicKeywordService
+from app.services.music_suggestion_service import MusicSuggestionService
+from app.schemas.song import SongSuggestion
+from app.state.music import get_latest_music
+
+
+def test_generate_music_recommendation_task_sets_track(monkeypatch, temp_session):
+    db = temp_session()
+    try:
+        db.add(models.Journal(content="j1", created_at=datetime.utcnow()))
+        db.commit()
+    finally:
+        db.close()
+
+    # Inject minimal settings so the services do not fail on import
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///./test.db")
+    monkeypatch.setenv("CELERY_BROKER_URL", "redis://localhost")
+    monkeypatch.setenv("CELERY_RESULT_BACKEND", "redis://localhost")
+    monkeypatch.setenv("SECRET_KEY", "x")
+
+    from app.tasks import generate_music_recommendation_task
+
+    monkeypatch.setattr("app.tasks.SessionLocal", temp_session)
+
+    async def fake_keyword(self, journals):
+        return "lofi"
+
+    async def fake_suggest(self, mood):
+        return [SongSuggestion(title="Song", artist="Artist")]
+
+    class DummySearch:
+        def __init__(self, query, limit=1):
+            self.query = query
+            self.limit = limit
+
+        def result(self):
+            return {"result": [{"id": "ytid"}]}
+
+    monkeypatch.setattr(MusicKeywordService, "generate_keyword", fake_keyword)
+    monkeypatch.setattr(MusicSuggestionService, "suggest_songs", fake_suggest)
+    monkeypatch.setattr("youtubesearchpython.VideosSearch", DummySearch)
+
+    generate_music_recommendation_task()
+    track = get_latest_music()
+    assert track is not None
+    assert track.title == "Song"
+    assert track.youtube_id == "ytid"


### PR DESCRIPTION
## Summary
- implement `generate_music_recommendation_task` to fetch a keyword, suggest songs, search YouTube and store latest track
- document the music background task
- add tests for the new task
- include `youtube-search-python` in backend requirements

## Testing
- `ruff check backend/app`
- `black backend/app --check`
- `pytest -q backend/tests/test_tasks.py`
- `pytest -q backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_686689c8991c832490c69e00d7d1f1a5