### PR TITLE
Update latest music flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Local notifications are powered by `flutter_local_notifications`. The
 `/quotes/latest` endpoint every 15 minutes. When a new quote is found a
 notification is shown and tapping it opens the quote detail screen.
 The app also polls `/music/latest` every 15 minutes to update the home screen
-with the newest song recommendation.
+with the newest track.
 
 On Android the default app icon is used for the notification. No additional
 configuration is required other than granting notification permissions on first
@@ -111,10 +111,9 @@ Only streams up to 160 kbps are considered and the highest quality URL within
 that range is returned. No
 YouTube API key is required.
 
-Audio suggestions come from the `/music/recommend` endpoint which analyses the
-latest journal entries through OpenRouter to generate a search keyword. That
-keyword is used to query Spotify and the resulting track IDs are then passed to
-`YoutubeAudioService` for playback.
+The latest track is fetched from the `/music/latest` endpoint which already
+includes a `youtube_id`. That ID is resolved by `YoutubeAudioService` into a
+playable URL for the audio player.
 
 To play the resolved URL using `just_audio` through `audio_service`:
 
@@ -208,7 +207,7 @@ backend can still be reached from the virtual device.
 
 ### App Usage
 
-Long‑press any message in the conversation to enter selection mode. A delete icon will appear in the top bar so you can remove the selected messages, similar to how WhatsApp handles chat message deletion. The home screen now automatically shows a recommended song based on your latest journals.
+Long‑press any message in the conversation to enter selection mode. A delete icon will appear in the top bar so you can remove the selected messages, similar to how WhatsApp handles chat message deletion. The home screen now automatically shows the latest track provided by the backend.
 
 ### Authentication workflow
 

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -215,7 +215,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i434.MusicUpdateService>(
       () => _i434.MusicUpdateService(
         gh<_i104.HomeApiService>(),
-        gh<_i176.SongSuggestionCacheRepository>(),
       ),
     );
     gh.lazySingleton<_i500.QuoteUpdateService>(
@@ -270,8 +269,7 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i119.LatestMusicCubit>(
       () => _i119.LatestMusicCubit(
-        gh<_i183.GetMusicSuggestionsUseCase>(),
-        gh<_i176.SongSuggestionCacheRepository>(),
+        gh<_i434.MusicUpdateService>(),
       ),
     );
     gh.factory<_i222.GetUserProfileUseCase>(

--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -1,35 +1,24 @@
-import 'package:dear_flutter/domain/usecases/get_music_suggestions_usecase.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
-import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
+import 'package:dear_flutter/services/music_update_service.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 
 @injectable
 class LatestMusicCubit extends Cubit<LatestMusicState> {
-  final GetMusicSuggestionsUseCase _getMusicSuggestionsUseCase;
-  final SongSuggestionCacheRepository _cacheRepository;
-  LatestMusicCubit(
-    this._getMusicSuggestionsUseCase,
-    this._cacheRepository,
-  ) : super(const LatestMusicState()) {
-    _loadCached();
-  }
-
-  void _loadCached() {
-    final cached = _cacheRepository.getLastSuggestions();
-    if (cached.isNotEmpty) {
-      emit(state.copyWith(status: LatestMusicStatus.cached, suggestions: cached));
+  final MusicUpdateService _updateService;
+  LatestMusicCubit(this._updateService) : super(const LatestMusicState()) {
+    final cached = _updateService.latest;
+    if (cached != null) {
+      emit(state.copyWith(status: LatestMusicStatus.cached, track: cached));
     }
   }
 
   Future<void> fetchLatestMusic() async {
     emit(state.copyWith(status: LatestMusicStatus.loading));
-    try {
-      final suggestions = await _getMusicSuggestionsUseCase('Netral');
-      emit(state.copyWith(
-          status: LatestMusicStatus.success, suggestions: suggestions));
-      await _cacheRepository.saveSuggestions(suggestions);
-    } catch (_) {
+    final track = await _updateService.refresh();
+    if (track != null) {
+      emit(state.copyWith(status: LatestMusicStatus.success, track: track));
+    } else {
       emit(state.copyWith(
         status: LatestMusicStatus.failure,
         errorMessage: 'Gagal memuat musik.',

--- a/lib/presentation/home/cubit/latest_music_state.dart
+++ b/lib/presentation/home/cubit/latest_music_state.dart
@@ -1,4 +1,4 @@
-import 'package:dear_flutter/domain/entities/song_suggestion.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'latest_music_state.freezed.dart';
@@ -9,7 +9,7 @@ enum LatestMusicStatus { initial, loading, cached, success, failure }
 class LatestMusicState with _$LatestMusicState {
   const factory LatestMusicState({
     @Default(LatestMusicStatus.initial) LatestMusicStatus status,
-    @Default([]) List<SongSuggestion> suggestions,
+    AudioTrack? track,
     String? errorMessage,
   }) = _LatestMusicState;
 }

--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -1,19 +1,17 @@
 import 'dart:async';
 
 import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
-import 'package:dear_flutter/domain/entities/song_suggestion.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
 import 'package:injectable/injectable.dart';
-import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart';
 
 @LazySingleton()
 class MusicUpdateService {
   final HomeApiService _apiService;
-  final SongSuggestionCacheRepository _cacheRepository;
 
   Timer? _timer;
-  List<SongSuggestion> _latest = const [];
+  AudioTrack? _latest;
 
-  MusicUpdateService(this._apiService, this._cacheRepository);
+  MusicUpdateService(this._apiService);
 
   void start() {
     _timer?.cancel();
@@ -21,16 +19,17 @@ class MusicUpdateService {
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
-  List<SongSuggestion> get latest =>
-      _latest.isNotEmpty ? _latest : _cacheRepository.getLastSuggestions();
+  Future<AudioTrack?> refresh() => _fetch();
 
-  Future<void> _fetch() async {
+  AudioTrack? get latest => _latest;
+
+  Future<AudioTrack?> _fetch() async {
     try {
-      final suggestions = await _apiService.getSuggestedMusic('Netral');
-      _latest = suggestions;
-      await _cacheRepository.saveSuggestions(suggestions);
+      _latest = await _apiService.getLatestMusic();
+      return _latest;
     } catch (_) {
       // ignore errors
+      return null;
     }
   }
 

--- a/test/home_screen_cached_test.dart
+++ b/test/home_screen_cached_test.dart
@@ -4,7 +4,6 @@ import 'package:dear_flutter/presentation/home/cubit/latest_quote_cubit.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
 import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
 import 'package:dear_flutter/domain/entities/motivational_quote.dart';
-import 'package:dear_flutter/domain/entities/song_suggestion.dart';
 import 'package:dear_flutter/domain/entities/audio_track.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -19,7 +18,7 @@ class _CachedMusicCubit extends Cubit<LatestMusicState>
   _CachedMusicCubit()
       : super(const LatestMusicState(
           status: LatestMusicStatus.cached,
-          suggestions: [SongSuggestion(title: 't', artist: 'a')],
+          track: AudioTrack(id: 1, title: 't', youtubeId: 'y', artist: 'a'),
         ));
 
   @override

--- a/test/home_screen_player_test.dart
+++ b/test/home_screen_player_test.dart
@@ -2,14 +2,13 @@ import 'dart:async';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:dear_flutter/domain/entities/motivational_quote.dart';
-import 'package:dear_flutter/domain/entities/song_suggestion.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_cubit.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_quote_cubit.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
 import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
 import 'package:dear_flutter/services/audio_player_handler.dart';
-import 'package:dear_flutter/services/youtube_search_service.dart';
 import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -23,7 +22,7 @@ class _FakeMusicCubit extends Cubit<LatestMusicState>
   _FakeMusicCubit()
       : super(const LatestMusicState(
           status: LatestMusicStatus.success,
-          suggestions: [SongSuggestion(title: 't', artist: 'a')],
+          track: AudioTrack(id: 1, title: 't', youtubeId: 'id', artist: 'a'),
         ));
 
   @override
@@ -42,7 +41,6 @@ class _FakeQuoteCubit extends Cubit<LatestQuoteState>
   Future<void> fetchLatestQuote() async {}
 }
 
-class _MockSearchService extends Mock implements YoutubeSearchService {}
 
 class _MockHandler extends Mock implements AudioPlayerHandler {}
 
@@ -62,10 +60,6 @@ void main() {
 
   testWidgets('tapping music card plays and shows player bar',
       (WidgetTester tester) async {
-    final search = _MockSearchService();
-    when(() => search.search(any()))
-        .thenAnswer((_) async => YoutubeSearchResult('id', 'thumb'));
-    getIt.registerSingleton<YoutubeSearchService>(search);
 
     final handler = _MockHandler();
     final controller = BehaviorSubject<PlaybackState>();

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,30 +5,29 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
-import 'package:dear_flutter/domain/entities/song_suggestion.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_cubit.dart';
 import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
-import 'package:dear_flutter/services/youtube_search_service.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
 import 'package:audio_service/audio_service.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:dear_flutter/services/audio_player_handler.dart';
 import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
 
-const _sampleSuggestion = SongSuggestion(title: 't', artist: 'a');
+const _sampleTrack =
+    AudioTrack(id: 1, title: 't', youtubeId: 'id', artist: 'a');
 
 class _FakeLatestMusicCubit extends Cubit<LatestMusicState>
     implements LatestMusicCubit {
   _FakeLatestMusicCubit()
       : super(const LatestMusicState(
           status: LatestMusicStatus.success,
-          suggestions: [_sampleSuggestion],
+          track: _sampleTrack,
         ));
 
   @override
   Future<void> fetchLatestMusic() async {}
 }
 
-class _MockSearchService extends Mock implements YoutubeSearchService {}
 class _MockHandler extends Mock implements AudioPlayerHandler {}
 class _MockSongHistoryRepository extends Mock implements SongHistoryRepository {}
 
@@ -41,11 +40,6 @@ void main() {
   setUp(() {
     getIt.reset();
     getIt.registerFactory<LatestMusicCubit>(() => _FakeLatestMusicCubit());
-    final search = _MockSearchService();
-    when(() => search.search(any())).thenAnswer(
-      (_) async => YoutubeSearchResult('id', 'thumb'),
-    );
-    getIt.registerSingleton<YoutubeSearchService>(search);
     handler = _MockHandler();
     getIt.registerSingleton<AudioPlayerHandler>(handler);
     getIt.registerSingleton<SongHistoryRepository>(_MockSongHistoryRepository());


### PR DESCRIPTION
## Summary
- fetch latest track via `/music/latest`
- adjust `LatestMusicCubit` to use `MusicUpdateService`
- display track instead of suggestions on home screen
- update tests and docs

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668bc912c08324a4ee1b451c2bad59