### PR TITLE
Update READMEs for music recommendation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ Local notifications are powered by `flutter_local_notifications`. The
 `NotificationService` is initialized in `main.dart` and automatically polls the
 `/quotes/latest` endpoint every 15 minutes. When a new quote is found a
 notification is shown and tapping it opens the quote detail screen.
-The app also polls `/music/latest` every 15 minutes to update the home screen
-with the newest track.
+
+The backend runs a Celery task named `generate_music_recommendation_task`
+every 15 minutes. It stores its result in `/music/latest`, and the Flutter app
+polls this endpoint on the same schedule to update the home screen with the
+newest track.
 
 On Android the default app icon is used for the notification. No additional
 configuration is required other than granting notification permissions on first
@@ -100,6 +103,14 @@ pip install -r requirements.txt
 cd backend && uvicorn app.main:app --reload
 ```
 > **Note**: If you run `uvicorn` from outside `backend/`, export `PYTHONPATH=backend` or run `python -m uvicorn app.main:app --reload`.
+
+Start the Celery worker and beat alongside Uvicorn so background tasks such as
+`generate_music_recommendation_task` can store new quotes and tracks:
+
+```bash
+celery -A app.celery_app.celery_app worker --loglevel=info
+celery -A app.celery_app.celery_app beat --loglevel=info
+```
 
 ### YouTube Audio Service
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -44,5 +44,6 @@ the same schedule. It extracts a keyword from the most recent journals using
 `MusicKeywordService`, requests song suggestions via `MusicSuggestionService`,
 performs a lightweight YouTube search to resolve a `youtube_id`, and finally
 stores the resulting `AudioTrack` in memory via `set_latest_music`. The most
-recent track can be fetched from `/music/latest`.
+recent track can be fetched from `/music/latest`, which the Flutter app polls
+every 15 minutes.
 


### PR DESCRIPTION
## Summary
- note Celery-generated tracks on `/music/latest`
- document starting Celery worker and beat
- clarify backend polling interval for new music

## Testing
- `black . --check`
- `ruff check .`
- `dart format . --set-exit-if-changed` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668e59526c83249aadaabadb644c5d