### PR TITLE
Add cache for latest music

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -38,6 +38,8 @@ import 'package:dear_flutter/data/repositories/journal_repository_impl.dart'
     as _i485;
 import 'package:dear_flutter/data/repositories/quote_cache_repository_impl.dart'
     as _i658;
+import 'package:dear_flutter/data/repositories/latest_music_cache_repository_impl.dart'
+    as _i710;
 import 'package:dear_flutter/data/repositories/song_history_repository_impl.dart'
     as _i227;
 import 'package:dear_flutter/data/repositories/song_suggestion_cache_repository_impl.dart'
@@ -49,6 +51,8 @@ import 'package:dear_flutter/domain/repositories/journal_repository.dart'
     as _i614;
 import 'package:dear_flutter/domain/repositories/quote_cache_repository.dart'
     as _i139;
+import 'package:dear_flutter/domain/repositories/latest_music_cache_repository.dart'
+    as _i709;
 import 'package:dear_flutter/domain/repositories/song_history_repository.dart'
     as _i448;
 import 'package:dear_flutter/domain/repositories/song_suggestion_cache_repository.dart'
@@ -166,6 +170,11 @@ extension GetItInjectableX on _i174.GetIt {
       instanceName: 'quoteBox',
       preResolve: true,
     );
+    await gh.lazySingletonAsync<_i979.Box<Map<dynamic, dynamic>>>(
+      () => registerModule.latestMusicBox,
+      instanceName: 'latestMusicBox',
+      preResolve: true,
+    );
     gh.lazySingleton<_i176.SongSuggestionCacheRepository>(
       () => _i14.SongSuggestionCacheRepositoryImpl(
         gh<_i979.Box<Map<dynamic, dynamic>>>(instanceName: 'suggestionBox'),
@@ -177,6 +186,11 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i139.QuoteCacheRepository>(
       () => _i658.QuoteCacheRepositoryImpl(
         gh<_i979.Box<Map<dynamic, dynamic>>>(instanceName: 'quoteBox'),
+      ),
+    );
+    gh.lazySingleton<_i709.LatestMusicCacheRepository>(
+      () => _i710.LatestMusicCacheRepositoryImpl(
+        gh<_i979.Box<Map<dynamic, dynamic>>>(instanceName: 'latestMusicBox'),
       ),
     );
     gh.factory<_i498.AuthInterceptor>(
@@ -261,7 +275,10 @@ extension GetItInjectableX on _i174.GetIt {
       ),
     );
     gh.lazySingleton<_i434.MusicUpdateService>(
-      () => _i434.MusicUpdateService(gh<_i104.HomeApiService>()),
+      () => _i434.MusicUpdateService(
+        gh<_i104.HomeApiService>(),
+        gh<_i709.LatestMusicCacheRepository>(),
+      ),
     );
     gh.factory<_i568.LatestQuoteCubit>(
       () => _i568.LatestQuoteCubit(gh<_i500.QuoteUpdateService>()),

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -68,6 +68,12 @@ Dio dio(
   @lazySingleton
   Future<Box<Map>> get quoteBox => Hive.openBox<Map>('motivational_quotes');
 
+  @Named('latestMusicBox')
+  @preResolve
+  @lazySingleton
+  Future<Box<Map>> get latestMusicBox =>
+      Hive.openBox<Map>('latest_music');
+
   // --- AUDIO ---
   @lazySingleton
   YoutubeExplode youtubeExplode() => YoutubeExplode();

--- a/lib/data/repositories/latest_music_cache_repository_impl.dart
+++ b/lib/data/repositories/latest_music_cache_repository_impl.dart
@@ -1,0 +1,22 @@
+import 'package:hive/hive.dart';
+import 'package:injectable/injectable.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/domain/repositories/latest_music_cache_repository.dart';
+
+@LazySingleton(as: LatestMusicCacheRepository)
+class LatestMusicCacheRepositoryImpl implements LatestMusicCacheRepository {
+  final Box<Map> _box;
+
+  LatestMusicCacheRepositoryImpl(@Named('latestMusicBox') this._box);
+
+  @override
+  Future<void> saveTrack(AudioTrack track) =>
+      _box.put('latest', track.toJson());
+
+  @override
+  AudioTrack? getLastTrack() {
+    final data = _box.get('latest');
+    if (data == null) return null;
+    return AudioTrack.fromJson(Map<String, dynamic>.from(data));
+  }
+}

--- a/lib/domain/repositories/latest_music_cache_repository.dart
+++ b/lib/domain/repositories/latest_music_cache_repository.dart
@@ -1,0 +1,6 @@
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+
+abstract class LatestMusicCacheRepository {
+  Future<void> saveTrack(AudioTrack track);
+  AudioTrack? getLastTrack();
+}


### PR DESCRIPTION
## Summary
- create `LatestMusicCacheRepository` interface
- implement Hive-backed `LatestMusicCacheRepositoryImpl`
- register new Hive box and repository in `RegisterModule`
- use repository in `MusicUpdateService`
- wire dependencies manually in `injection.config.dart`

## Testing
- `dart format -o none --set-exit-if-changed .` *(fails: dart not found)*
- `dart analyze` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669e1eafc883249f3bde12d0af158a