### PR TITLE
Handle offline music state

### DIFF
--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -19,10 +19,19 @@ class LatestMusicCubit extends Cubit<LatestMusicState> {
     if (track != null) {
       emit(state.copyWith(status: LatestMusicStatus.success, track: track));
     } else {
-      emit(state.copyWith(
-        status: LatestMusicStatus.failure,
-        errorMessage: 'Gagal memuat musik.',
-      ));
+      final cached = _updateService.latest;
+      if (cached != null) {
+        emit(state.copyWith(
+          status: LatestMusicStatus.offline,
+          track: cached,
+          errorMessage: 'Gagal memuat musik.',
+        ));
+      } else {
+        emit(state.copyWith(
+          status: LatestMusicStatus.failure,
+          errorMessage: 'Gagal memuat musik.',
+        ));
+      }
     }
   }
 }

--- a/lib/presentation/home/cubit/latest_music_state.dart
+++ b/lib/presentation/home/cubit/latest_music_state.dart
@@ -3,7 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'latest_music_state.freezed.dart';
 
-enum LatestMusicStatus { initial, loading, cached, success, failure }
+enum LatestMusicStatus { initial, loading, cached, offline, success, failure }
 
 @freezed
 class LatestMusicState with _$LatestMusicState {

--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -112,6 +112,10 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final offlineState = context.watch<LatestMusicCubit>().state;
+    final playerTrack =
+        _currentTrack ?? (offlineState.status == LatestMusicStatus.offline ? offlineState.track : null);
+
     return MultiBlocProvider(
       providers: [
         BlocProvider(create: (_) => getIt<LatestMusicCubit>()),
@@ -137,9 +141,9 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
             ),
-            if (_currentTrack != null)
+            if (playerTrack != null)
               _PlayerBar(
-                track: _currentTrack!,
+                track: playerTrack,
                 isPlaying: _isPlaying,
                 isLoading: _loading,
                 position: _position,
@@ -223,6 +227,14 @@ class _MusicSection extends StatelessWidget {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (state.status == LatestMusicStatus.offline)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  'Offline – menampilkan lagu terakhir.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
             Text(
               'Rekomendasi Musik',
               style: Theme.of(context).textTheme.headlineSmall,

--- a/test/home_screen_offline_test.dart
+++ b/test/home_screen_offline_test.dart
@@ -1,0 +1,72 @@
+import 'package:dear_flutter/presentation/home/cubit/latest_music_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_quote_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
+import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:dear_flutter/services/audio_player_handler.dart';
+import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
+
+class _OfflineMusicCubit extends Cubit<LatestMusicState>
+    implements LatestMusicCubit {
+  _OfflineMusicCubit()
+      : super(const LatestMusicState(
+          status: LatestMusicStatus.offline,
+          track: AudioTrack(id: 1, title: 't', youtubeId: 'y', artist: 'a'),
+          errorMessage: 'err',
+        ));
+
+  @override
+  Future<void> fetchLatestMusic() async {}
+}
+
+class _CachedQuoteCubit extends Cubit<LatestQuoteState>
+    implements LatestQuoteCubit {
+  _CachedQuoteCubit()
+      : super(const LatestQuoteState(
+          status: LatestQuoteStatus.cached,
+          quote: MotivationalQuote(id: 1, text: 'q', author: 'a'),
+        ));
+
+  @override
+  Future<void> fetchLatestQuote() async {}
+}
+
+class _DummyHandler extends Mock implements AudioPlayerHandler {}
+
+class _FakeSongHistoryRepository implements SongHistoryRepository {
+  @override
+  Future<void> addTrack(AudioTrack track) async {}
+
+  @override
+  List<AudioTrack> getHistory() => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final getIt = GetIt.instance;
+
+  setUp(() {
+    getIt.reset();
+    getIt.registerFactory<LatestMusicCubit>(() => _OfflineMusicCubit());
+    getIt.registerFactory<LatestQuoteCubit>(() => _CachedQuoteCubit());
+    getIt.registerSingleton<AudioPlayerHandler>(_DummyHandler());
+    getIt.registerSingleton<SongHistoryRepository>(_FakeSongHistoryRepository());
+  });
+
+  tearDown(getIt.reset);
+
+  testWidgets('shows offline message and music card', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+
+    expect(find.byType(HomeScreen), findsOneWidget);
+    expect(find.text('Offline – menampilkan lagu terakhir.'), findsOneWidget);
+    expect(find.text('t'), findsOneWidget);
+  });
+}

--- a/test/latest_music_cubit_test.dart
+++ b/test/latest_music_cubit_test.dart
@@ -38,4 +38,17 @@ void main() {
     expect(cubit.state.track, track);
     verify(service.refresh).called(1);
   });
+
+  test('emits offline when refresh fails but cached track exists', () async {
+    final service = _MockMusicUpdateService();
+    when(() => service.latest).thenReturn(track);
+    when(service.refresh).thenAnswer((_) async => null);
+
+    final cubit = LatestMusicCubit(service);
+    await cubit.fetchLatestMusic();
+
+    expect(cubit.state.status, LatestMusicStatus.offline);
+    expect(cubit.state.track, track);
+    expect(cubit.state.errorMessage, isNotNull);
+  });
 }


### PR DESCRIPTION
## Summary
- extend `LatestMusicStatus` with an `offline` state
- update `LatestMusicCubit.fetchLatestMusic` to emit `offline` when refresh fails but cache exists
- show an offline notice in the home screen music section
- keep the player bar visible using the cached track when offline
- add tests for the new offline behaviour

## Testing
- `dart format -o none lib test` *(fails: dart not installed)*
- `dart analyze` *(fails: dart not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68669fe87ce4832481d086544c616a4e