### PR TITLE
Add offline state tests

### DIFF
--- a/test/home_screen_offline_message_test.dart
+++ b/test/home_screen_offline_message_test.dart
@@ -1,0 +1,72 @@
+import 'package:dear_flutter/presentation/home/cubit/latest_music_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_quote_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
+import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:dear_flutter/services/audio_player_handler.dart';
+import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
+
+class _OfflineMusicCubit extends Cubit<LatestMusicState>
+    implements LatestMusicCubit {
+  _OfflineMusicCubit()
+      : super(const LatestMusicState(
+          status: LatestMusicStatus.offline,
+          track: AudioTrack(id: 1, title: 't', youtubeId: 'y', artist: 'a'),
+          errorMessage: 'err',
+        ));
+
+  @override
+  Future<void> fetchLatestMusic() async {}
+}
+
+class _CachedQuoteCubit extends Cubit<LatestQuoteState>
+    implements LatestQuoteCubit {
+  _CachedQuoteCubit()
+      : super(const LatestQuoteState(
+          status: LatestQuoteStatus.cached,
+          quote: MotivationalQuote(id: 1, text: 'q', author: 'a'),
+        ));
+
+  @override
+  Future<void> fetchLatestQuote() async {}
+}
+
+class _DummyHandler extends Mock implements AudioPlayerHandler {}
+
+class _FakeSongHistoryRepository implements SongHistoryRepository {
+  @override
+  Future<void> addTrack(AudioTrack track) async {}
+
+  @override
+  List<AudioTrack> getHistory() => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final getIt = GetIt.instance;
+
+  setUp(() {
+    getIt.reset();
+    getIt.registerFactory<LatestMusicCubit>(() => _OfflineMusicCubit());
+    getIt.registerFactory<LatestQuoteCubit>(() => _CachedQuoteCubit());
+    getIt.registerSingleton<AudioPlayerHandler>(_DummyHandler());
+    getIt.registerSingleton<SongHistoryRepository>(_FakeSongHistoryRepository());
+  });
+
+  tearDown(getIt.reset);
+
+  testWidgets('displays offline message and music card',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+
+    expect(find.text('Offline – menampilkan lagu terakhir.'), findsOneWidget);
+    expect(find.text('t'), findsOneWidget);
+  });
+}

--- a/test/latest_music_cubit_test.dart
+++ b/test/latest_music_cubit_test.dart
@@ -51,4 +51,35 @@ void main() {
     expect(cubit.state.track, track);
     expect(cubit.state.errorMessage, isNotNull);
   });
+
+  test('emits loading then offline state when refresh returns null', () async {
+    final service = _MockMusicUpdateService();
+    when(() => service.latest).thenReturn(track);
+    when(service.refresh).thenAnswer((_) async => null);
+
+    final cubit = LatestMusicCubit(service);
+
+    final expectation = expectLater(
+      cubit.stream.skip(1),
+      emitsInOrder([
+        isA<LatestMusicState>().having(
+          (s) => s.status,
+          'status',
+          LatestMusicStatus.loading,
+        ),
+        isA<LatestMusicState>().having(
+          (s) => s.status,
+          'status',
+          LatestMusicStatus.offline,
+        ).having((s) => s.track, 'track', track).having(
+          (s) => s.errorMessage,
+          'errorMessage',
+          isNotNull,
+        ),
+      ]),
+    );
+
+    await cubit.fetchLatestMusic();
+    await expectation;
+  });
 }


### PR DESCRIPTION
## Summary
- verify sequence to offline state in `LatestMusicCubit`
- test HomeScreen offline message display

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a1df7ce08324828b0b6f24e4a386