### PR TITLE
Update bottom navigation tabs

### DIFF
--- a/lib/core/navigation/app_router.dart
+++ b/lib/core/navigation/app_router.dart
@@ -6,6 +6,8 @@ import 'package:dear_flutter/presentation/chat/screens/chat_screen.dart';
 import 'package:dear_flutter/presentation/home/screens/home_screen.dart';
 import 'package:dear_flutter/presentation/main/main_screen.dart';
 import 'package:dear_flutter/presentation/profile/screens/profile_screen.dart'; // Sudah ditambahkan
+import 'package:dear_flutter/presentation/journal/screens/journal_editor_screen.dart';
+import 'package:dear_flutter/presentation/psy/screens/psy_screen.dart';
 import 'package:dear_flutter/presentation/home/screens/article_detail_screen.dart';
 import 'package:dear_flutter/presentation/home/screens/audio_player_screen.dart';
 import 'package:dear_flutter/presentation/home/screens/quote_detail_screen.dart';
@@ -22,13 +24,13 @@ final GoRouter router = GoRouter(
   initialLocation: '/home',
   navigatorKey: _rootNavigatorKey,
   routes: [
-    // ShellRoute dengan 3 tab utama
+    // ShellRoute dengan 5 tab utama
     StatefulShellRoute.indexedStack(
       builder: (context, state, navigationShell) {
         return MainScreen(child: navigationShell);
       },
       branches: [
-        // Tab 0: Beranda
+        // Tab 0: Home
         StatefulShellBranch(
           routes: [
             GoRoute(
@@ -48,7 +50,27 @@ final GoRouter router = GoRouter(
             ),
           ],
         ),
-        // Tab 2: Profil (tambahan)
+        // Tab 2: Create Journal
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/journal',
+              pageBuilder: (context, state) =>
+                  const NoTransitionPage(child: JournalEditorScreen()),
+            ),
+          ],
+        ),
+        // Tab 3: Psy
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/psy',
+              pageBuilder: (context, state) =>
+                  const NoTransitionPage(child: PsyScreen()),
+            ),
+          ],
+        ),
+        // Tab 4: Profil
         StatefulShellBranch(
           routes: [
             GoRoute(

--- a/lib/presentation/main/main_screen.dart
+++ b/lib/presentation/main/main_screen.dart
@@ -20,12 +20,22 @@ class MainScreen extends StatelessWidget {
           BottomNavigationBarItem(
             icon: Icon(Icons.home_outlined),
             activeIcon: Icon(Icons.home),
-            label: 'Beranda',
+            label: 'Home',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.chat_bubble_outline),
             activeIcon: Icon(Icons.chat_bubble),
             label: 'Chat',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.add_circle_outline),
+            activeIcon: Icon(Icons.add_circle),
+            label: 'Jurnal',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.psychology_outlined),
+            activeIcon: Icon(Icons.psychology),
+            label: 'Psy',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.person_outline),
@@ -42,7 +52,9 @@ class MainScreen extends StatelessWidget {
     final String location = GoRouterState.of(context).matchedLocation;
     if (location.startsWith('/home')) return 0;
     if (location.startsWith('/chat')) return 1;
-    if (location.startsWith('/profile')) return 2;
+    if (location.startsWith('/journal')) return 2;
+    if (location.startsWith('/psy')) return 3;
+    if (location.startsWith('/profile')) return 4;
     return 0;
   }
 
@@ -56,6 +68,12 @@ class MainScreen extends StatelessWidget {
         context.go('/chat');
         break;
       case 2:
+        context.go('/journal');
+        break;
+      case 3:
+        context.go('/psy');
+        break;
+      case 4:
         context.go('/profile');
         break;
     }

--- a/lib/presentation/psy/screens/psy_screen.dart
+++ b/lib/presentation/psy/screens/psy_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class PsyScreen extends StatelessWidget {
+  const PsyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(
+        title: Text('Psy'),
+      ),
+      body: Center(
+        child: Text('Coming soon...'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add PsyScreen placeholder
- wire 5-tab navigation in app router
- update main screen bottom navigation layout

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a72018d483249bf611f2cf213479