### PR TITLE
fix(ui): navigate to home after journal save

### DIFF
--- a/lib/presentation/journal/screens/journal_editor_screen.dart
+++ b/lib/presentation/journal/screens/journal_editor_screen.dart
@@ -30,7 +30,9 @@ class _JournalEditorScreenState extends State<JournalEditorScreen> {
         listener: (context, state) {
           if (state.status == JournalEditorStatus.success) {
             // Jika sukses, kembali ke halaman sebelumnya
-            Navigator.of(context).pop();
+            // Gunakan GoRouter untuk memastikan navigasi tidak memicu error
+            // saat stack kosong
+            context.go('/home');
           }
           if (state.status == JournalEditorStatus.failure) {
             // Jika gagal, tampilkan Snackbar


### PR DESCRIPTION
## Summary
- use `context.go('/home')` after a successful journal save to avoid empty stack error

## Issue
- fixes issue where the app crashed after saving journal and popping the stack

## Testing
- `dart format lib/presentation/journal/screens/journal_editor_screen.dart` *(fails: dart not installed)*
- `dart analyze` *(fails: dart not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866aa9787908324a876d63841674b69