### PR TITLE
Add .env example for backend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,12 @@
+DATABASE_URL=sqlite:///./test.db
+SECRET_KEY=supersecretkey
+OPENROUTER_API_KEY=
+PLANNER_MODEL_NAME=deepseek/deepseek-chat-v3-0324
+GENERATOR_MODEL_NAME=deepseek/deepseek-chat-v3-0324
+APP_SITE_URL=http://localhost
+APP_NAME=Dear Diary API
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+ENVIRONMENT=development
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+SENTRY_DSN=

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,6 +6,7 @@ This directory hosts the FastAPI service for Dear Diary.
 
 Create and activate a virtual environment, then install dependencies:
 
+
 ```bash
 python3 -m venv venv
 source venv/bin/activate
@@ -16,6 +17,8 @@ pip install -r requirements.txt
 > starting Uvicorn. Omitting it can lead to import errors such as
 > `ModuleNotFoundError` if required packages are missing.
 
+Copy `backend/.env.example` to `.env` and edit the values before running the server.
+
 Run the development server from within this directory:
 
 ```bash
@@ -25,9 +28,8 @@ gunicorn --preload -w 4 -k uvicorn.workers.UvicornWorker app.main:app
 
 ## Configuration
 
-Copy `.env.example` to `.env` and edit the values before running the server.
-The repository includes `.env.example` with placeholders for all environment
-variables (e.g. `DATABASE_URL` and `OPENROUTER_API_KEY`).
+See `.env.example` for the list of required environment variables including
+`DATABASE_URL` and `OPENROUTER_API_KEY`.
 
 ## Background tasks
 


### PR DESCRIPTION
## Summary
- provide `.env.example` with development defaults
- reference `.env.example` setup in backend README

## Testing
- `black . --check`
- `ruff check .`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6866b07a9afc83249080edf4ff4c7bca