### PR TITLE
Add config change guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@
 -   Jangan pernah menyimpan rahasia atau kredensial sensitif secara *hardcode* di dalam file sumber.
 -   Untuk setiap integrasi AI atau alat otomatis, dokumentasikan input/output yang diharapkan dan contoh *prompt*/perintah utama di `README` atau dokumentasi fitur yang relevan.
 -   Selalu perbarui semua `README`, `AGENTS.md`, dan dokumentasi yang ditujukan untuk pengembang dengan setiap perubahan struktural atau proses.
+-   Jika mengubah berkas konfigurasi (misalnya `.env`, `config/*.json`, `android/app/build.gradle.kts`), tambahkan komentar singkat atau baris `# TODO:` pada nilai yang diubah dan catat alasannya di `docs/CONFIG_NOTES.md` beserta tanggal dan penulis.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Alternatively you can simply run `make test` which installs the requirements and
 
 Contributions are welcome! Please open issues or pull requests on GitHub. Make sure to format code and provide tests where relevant.
 
+- See [docs/CONFIG_NOTES.md](docs/CONFIG_NOTES.md) for how to document any configuration changes.
+
 - Use the commit message style `<type>(<scope>): <description>` as outlined in `AGENTS.md`. For example: `fix(ui): resolve newline issues`.
 
 ## Profiling

--- a/docs/CONFIG_NOTES.md
+++ b/docs/CONFIG_NOTES.md
@@ -1,0 +1,11 @@
+# Config Change Notes
+
+This file tracks configuration updates across the project.
+
+- When modifying values in `.env`, `config/*.json`, `android/app/build.gradle.kts` or any other config file, add a short comment or `# TODO:` line nearby explaining the change.
+- Log the reason for each modification below with the date and your name.
+
+```
+[YYYY-MM-DD] Author - Reason for change
+```
+


### PR DESCRIPTION
## Summary
- document how to record configuration changes in `docs/CONFIG_NOTES.md`
- reference configuration notes from `README.md`
- update `AGENTS.md` instructions for configuration edits

## Testing
- `black . --check`
- `ruff check .`
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866b22bba548324ba310792e86cd12a