### PR TITLE
fix(home): auto-fetch content on home startup

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -114,8 +114,12 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
-        BlocProvider(create: (_) => getIt<LatestMusicCubit>()),
-        BlocProvider(create: (_) => getIt<LatestQuoteCubit>()),
+        BlocProvider(
+          create: (_) => getIt<LatestMusicCubit>()..fetchLatestMusic(),
+        ),
+        BlocProvider(
+          create: (_) => getIt<LatestQuoteCubit>()..fetchLatestQuote(),
+        ),
       ],
       child: Scaffold(
         appBar: null,


### PR DESCRIPTION
## Summary
- auto-load latest music and quote when Home loads

## Issue
- n/a

## Files Affected
- `lib/presentation/home/screens/home_screen.dart`

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b3fd36d48324a93a552732af8678