### PR TITLE
Start updates post-frame

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,10 +26,14 @@ Future<void> main() async {
     getIt.registerSingleton<AudioPlayerHandler>(handler);
   }
   await getIt<NotificationService>().init();
-  getIt<QuoteUpdateService>().start();
-  getIt<MusicUpdateService>().start();
 
   runApp(const MyApp());
+
+  // Delay starting services until after the first frame to prevent skipped-frame warnings
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    getIt<QuoteUpdateService>().start();
+    getIt<MusicUpdateService>().start();
+  });
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
## Summary
- start quote and music updates after the first frame to avoid skipped-frame warnings

## Issue
- n/a

## Files Affected
- `lib/main.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b6ee24c88324a2f9f4eef2a0b24d