### PR TITLE
Wrap logging with kDebugMode

### DIFF
--- a/lib/core/api/logging_interceptor.dart
+++ b/lib/core/api/logging_interceptor.dart
@@ -1,30 +1,33 @@
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show debugPrint, kDebugMode;
 import 'package:injectable/injectable.dart';
 
 @lazySingleton
 class LoggingInterceptor extends Interceptor {
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    debugPrint('--> ${options.method} ${options.uri}');
-    debugPrint('Headers: ${options.headers}');
+    if (kDebugMode) debugPrint('--> ${options.method} ${options.uri}');
+    if (kDebugMode) debugPrint('Headers: ${options.headers}');
     if (options.data != null) {
-      debugPrint('Body: ${options.data}');
+      if (kDebugMode) debugPrint('Body: ${options.data}');
     }
     super.onRequest(options, handler);
   }
 
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
-    debugPrint(
-        '<-- ${response.statusCode} ${response.requestOptions.uri}');
+    if (kDebugMode) {
+      debugPrint('<-- ${response.statusCode} ${response.requestOptions.uri}');
+    }
     super.onResponse(response, handler);
   }
 
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
-    debugPrint(
-        'ERROR[${err.response?.statusCode}] => ${err.requestOptions.method} ${err.requestOptions.uri}: ${err.message}');
+    if (kDebugMode) {
+      debugPrint(
+          'ERROR[${err.response?.statusCode}] => ${err.requestOptions.method} ${err.requestOptions.uri}: ${err.message}');
+    }
     super.onError(err, handler);
   }
 }


### PR DESCRIPTION
## Summary
- ensure logging occurs only in debug mode

## Testing
- `dart format lib/core/api/logging_interceptor.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b766d6d88324b256c34c30cc0d68