### PR TITLE
Make celery tasks async

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ Start the Celery worker and beat alongside Uvicorn so background tasks such as
 `generate_music_recommendation_task` can store new quotes and tracks:
 
 ```bash
-celery -A app.celery_app.celery_app worker --loglevel=info
+celery -A app.celery_app.celery_app worker --loglevel=info -P solo
 celery -A app.celery_app.celery_app beat --loglevel=info
 ```
+The `solo` pool ensures that Celery can await these asynchronous tasks properly.
 
 ### YouTube Audio Service
 

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 from app import models
 from app.services.music_keyword_service import MusicKeywordService
 from app.services.music_suggestion_service import MusicSuggestionService
@@ -7,7 +8,8 @@ from app.schemas.song import SongSuggestion
 from app.state.music import get_latest_music
 
 
-def test_generate_music_recommendation_task_sets_track(monkeypatch, temp_session):
+@pytest.mark.asyncio
+async def test_generate_music_recommendation_task_sets_track(monkeypatch, temp_session):
     db = temp_session()
     try:
         db.add(models.Journal(content="j1", created_at=datetime.utcnow()))
@@ -43,7 +45,7 @@ def test_generate_music_recommendation_task_sets_track(monkeypatch, temp_session
     monkeypatch.setattr(MusicSuggestionService, "suggest_songs", fake_suggest)
     monkeypatch.setattr("youtubesearchpython.VideosSearch", DummySearch)
 
-    generate_music_recommendation_task()
+    await generate_music_recommendation_task()
     track = get_latest_music()
     assert track is not None
     assert track.title == "Song"


### PR DESCRIPTION
## Summary
- make `generate_quote_task` and `generate_music_recommendation_task` async
- update Celery worker command in README
- adjust task test for async functions

## Testing
- `black backend/app/tasks.py backend/tests/test_tasks.py`
- `ruff check backend/app/tasks.py backend/tests/test_tasks.py`
- `pytest backend/tests/test_tasks.py::test_generate_music_recommendation_task_sets_track -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6866b8e45e48832492ba7719c7c3c237