### PR TITLE
Move home widgets and add docs

### DIFF
--- a/lib/presentation/home/screens/article_detail_screen.dart
+++ b/lib/presentation/home/screens/article_detail_screen.dart
@@ -2,7 +2,10 @@ import 'package:dear_flutter/domain/entities/article.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
+/// Displays an article inside a WebView.
+
 class ArticleDetailScreen extends StatefulWidget {
+
   const ArticleDetailScreen({super.key, required this.article});
 
   final Article article;

--- a/lib/presentation/home/screens/audio_player_screen.dart
+++ b/lib/presentation/home/screens/audio_player_screen.dart
@@ -7,7 +7,10 @@ import 'package:dear_flutter/core/di/injection.dart';
 import 'package:dear_flutter/domain/repositories/song_history_repository.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart';
 
+/// Fullscreen audio player for a single track.
+
 class AudioPlayerScreen extends StatefulWidget {
+
   const AudioPlayerScreen({super.key, required this.track});
 
   final AudioTrack track;

--- a/lib/presentation/home/screens/quote_detail_screen.dart
+++ b/lib/presentation/home/screens/quote_detail_screen.dart
@@ -3,7 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:share_plus/share_plus.dart';
 
+/// Shows a quote with sharing actions.
+
 class QuoteDetailScreen extends StatelessWidget {
+
   const QuoteDetailScreen({super.key, required this.quote});
 
   final MotivationalQuote quote;

--- a/lib/presentation/home/widgets/music_section.dart
+++ b/lib/presentation/home/widgets/music_section.dart
@@ -1,0 +1,100 @@
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_music_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_music_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// Shows the latest recommended music track.
+class MusicSection extends StatelessWidget {
+  const MusicSection({super.key, required this.onPlay, required this.loading});
+
+  final Future<void> Function(AudioTrack) onPlay;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<LatestMusicCubit, LatestMusicState>(
+      builder: (context, state) {
+        if (state.status == LatestMusicStatus.loading) {
+          return const _ShimmerMusicCard();
+        }
+        if (state.status == LatestMusicStatus.failure) {
+          return Center(
+            child: Text(state.errorMessage ?? 'Terjadi kesalahan'),
+          );
+        }
+        final track = state.track;
+        if (track == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Rekomendasi Musik',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 16),
+            _MusicCard(
+              track: track,
+              onTap: () => onPlay(track),
+              loading: loading,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ShimmerMusicCard extends StatelessWidget {
+  const _ShimmerMusicCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: Colors.grey[300]!,
+      highlightColor: Colors.grey[100]!,
+      child: Card(
+        child: ListTile(
+          leading: Icon(Icons.music_note, color: Colors.grey[400]),
+          title: Container(height: 20.0, color: Colors.grey[400]),
+          subtitle: Container(height: 15.0, color: Colors.grey[300]),
+        ),
+      ),
+    );
+  }
+}
+
+class _MusicCard extends StatelessWidget {
+  const _MusicCard({
+    required this.track,
+    required this.onTap,
+    required this.loading,
+  });
+
+  final AudioTrack track;
+  final VoidCallback onTap;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.music_note),
+        title: Text(track.title),
+        subtitle: Text(track.artist ?? ''),
+        onTap: onTap,
+        trailing: loading
+            ? const SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : null,
+      ),
+    );
+  }
+}

--- a/lib/presentation/home/widgets/player_bar.dart
+++ b/lib/presentation/home/widgets/player_bar.dart
@@ -1,0 +1,97 @@
+import 'package:dear_flutter/domain/entities/audio_track.dart';
+import 'package:flutter/material.dart';
+
+/// Player bar widget for controlling playback.
+class PlayerBar extends StatelessWidget {
+  const PlayerBar({
+    super.key,
+    required this.track,
+    required this.isPlaying,
+    required this.isLoading,
+    required this.position,
+    required this.duration,
+    required this.onToggle,
+    required this.onSeek,
+  });
+
+  final AudioTrack track;
+  final bool isPlaying;
+  final bool isLoading;
+  final Duration position;
+  final Duration duration;
+  final VoidCallback onToggle;
+  final ValueChanged<double> onSeek;
+
+  @override
+  Widget build(BuildContext context) {
+    final max = duration.inMilliseconds.toDouble();
+    final value = position.inMilliseconds.clamp(0, max).toDouble();
+
+    String fmt(Duration d) {
+      final minutes = d.inMinutes.remainder(60).toString().padLeft(2, '0');
+      final seconds = d.inSeconds.remainder(60).toString().padLeft(2, '0');
+      final hours = d.inHours;
+      return hours > 0 ? '$hours:$minutes:$seconds' : '$minutes:$seconds';
+    }
+
+    return Material(
+      color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Slider(
+            min: 0,
+            max: max > 0 ? max : 1,
+            value: value,
+            onChanged: onSeek,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                if (track.coverUrl != null)
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(4),
+                    child: Image.network(
+                      track.coverUrl!,
+                      height: 40,
+                      width: 40,
+                      fit: BoxFit.cover,
+                    ),
+                  )
+                else
+                  Container(height: 40, width: 40, color: Colors.grey),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        track.title,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Text(
+                        '${fmt(position)} / ${fmt(duration)}',
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ],
+                  ),
+                ),
+                isLoading
+                    ? const SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : IconButton(
+                        icon: Icon(isPlaying ? Icons.pause : Icons.play_arrow),
+                        onPressed: onToggle,
+                      ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/home/widgets/quote_section.dart
+++ b/lib/presentation/home/widgets/quote_section.dart
@@ -1,0 +1,68 @@
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_quote_cubit.dart';
+import 'package:dear_flutter/presentation/home/cubit/latest_quote_state.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shimmer/shimmer.dart';
+
+/// Displays the latest motivational quote.
+class QuoteSection extends StatelessWidget {
+  const QuoteSection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<LatestQuoteCubit, LatestQuoteState>(
+      builder: (context, state) {
+        if (state.status == LatestQuoteStatus.loading) {
+          return const _ShimmerQuoteCard();
+        }
+        if (state.status == LatestQuoteStatus.failure) {
+          return Center(
+            child: Text(state.errorMessage ?? 'Terjadi kesalahan'),
+          );
+        }
+        final quote = state.quote;
+        if (quote == null) return const SizedBox.shrink();
+        return _QuoteCard(quote: quote);
+      },
+    );
+  }
+}
+
+class _ShimmerQuoteCard extends StatelessWidget {
+  const _ShimmerQuoteCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: Colors.grey[300]!,
+      highlightColor: Colors.grey[100]!,
+      child: Card(
+        child: ListTile(
+          leading: Icon(Icons.format_quote, color: Colors.grey[400]),
+          title: Container(height: 20.0, color: Colors.grey[400]),
+          subtitle: Container(height: 15.0, color: Colors.grey[300]),
+        ),
+      ),
+    );
+  }
+}
+
+class _QuoteCard extends StatelessWidget {
+  const _QuoteCard({required this.quote});
+
+  final MotivationalQuote quote;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.format_quote),
+        title: Text('"${quote.text}"'),
+        subtitle: Text(quote.author),
+        onTap: () => context.go('/quote', extra: quote),
+      ),
+    );
+  }
+}

--- a/lib/presentation/home/widgets/widgets.dart
+++ b/lib/presentation/home/widgets/widgets.dart
@@ -1,0 +1,3 @@
+export 'quote_section.dart';
+export 'music_section.dart';
+export 'player_bar.dart';


### PR DESCRIPTION
## Summary
- document HomeScreen and helper screens
- extract QuoteSection, MusicSection and PlayerBar widgets
- export the new widgets and use them in HomeScreen

## Testing
- `dart format .` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bb7cd1f08324a5b706ea821c6282