### PR TITLE
Handle cached fetch in update services

### DIFF
--- a/lib/presentation/home/cubit/latest_music_cubit.dart
+++ b/lib/presentation/home/cubit/latest_music_cubit.dart
@@ -14,6 +14,14 @@ class LatestMusicCubit extends Cubit<LatestMusicState> {
   }
 
   Future<void> fetchLatestMusic() async {
+    if (_updateService.hasFetchedInitial) {
+      final cached = _updateService.latest;
+      if (cached != null) {
+        emit(state.copyWith(status: LatestMusicStatus.success, track: cached));
+      }
+      return;
+    }
+
     emit(state.copyWith(status: LatestMusicStatus.loading));
     final track = await _updateService.refresh();
     if (track != null) {

--- a/lib/presentation/home/cubit/latest_quote_cubit.dart
+++ b/lib/presentation/home/cubit/latest_quote_cubit.dart
@@ -15,6 +15,14 @@ class LatestQuoteCubit extends Cubit<LatestQuoteState> {
   }
 
   Future<void> fetchLatestQuote() async {
+    if (_updateService.hasFetchedInitial) {
+      final cached = _updateService.latest;
+      if (cached != null) {
+        emit(state.copyWith(status: LatestQuoteStatus.success, quote: cached));
+      }
+      return;
+    }
+
     emit(state.copyWith(status: LatestQuoteStatus.loading));
     final quote = await _updateService.refresh();
     if (quote != null) {

--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -12,17 +12,21 @@ class MusicUpdateService {
 
   Timer? _timer;
   AudioTrack? _latest;
+  bool _initialFetchDone = false;
   MusicUpdateService(this._apiService, this._cacheRepository);
 
   void start() {
     _timer?.cancel();
-    _fetch();
+    _initialFetchDone = false;
+    _fetch().whenComplete(() => _initialFetchDone = true);
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
   Future<AudioTrack?> refresh() => _fetch();
 
   AudioTrack? get latest => _latest ?? _cacheRepository.getLastTrack();
+
+  bool get hasFetchedInitial => _initialFetchDone;
 
   Future<AudioTrack?> _fetch() async {
     try {

--- a/lib/services/quote_update_service.dart
+++ b/lib/services/quote_update_service.dart
@@ -15,6 +15,7 @@ class QuoteUpdateService {
 
   Timer? _timer;
   MotivationalQuote? _lastQuote;
+  bool _initialFetchDone = false;
 
   QuoteUpdateService(
       this._apiService, this._notificationService, this._cacheRepository);
@@ -24,11 +25,14 @@ class QuoteUpdateService {
 
   void start() {
     _timer?.cancel();
-    _fetch();
+    _initialFetchDone = false;
+    _fetch().whenComplete(() => _initialFetchDone = true);
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
   Future<MotivationalQuote?> refresh() => _fetch();
+
+  bool get hasFetchedInitial => _initialFetchDone;
 
   Future<MotivationalQuote?> _fetch() async {
     try {

--- a/test/latest_music_cubit_test.dart
+++ b/test/latest_music_cubit_test.dart
@@ -30,6 +30,7 @@ void main() {
     final service = _MockMusicUpdateService();
     when(() => service.latest).thenReturn(null);
     when(service.refresh).thenAnswer((_) async => track);
+    when(() => service.hasFetchedInitial).thenReturn(false);
 
     final cubit = LatestMusicCubit(service);
     await cubit.fetchLatestMusic();
@@ -43,6 +44,7 @@ void main() {
     final service = _MockMusicUpdateService();
     when(() => service.latest).thenReturn(track);
     when(service.refresh).thenAnswer((_) async => null);
+    when(() => service.hasFetchedInitial).thenReturn(false);
 
     final cubit = LatestMusicCubit(service);
     await cubit.fetchLatestMusic();
@@ -56,6 +58,7 @@ void main() {
     final service = _MockMusicUpdateService();
     when(() => service.latest).thenReturn(track);
     when(service.refresh).thenAnswer((_) async => null);
+    when(() => service.hasFetchedInitial).thenReturn(false);
 
     final cubit = LatestMusicCubit(service);
 
@@ -81,5 +84,18 @@ void main() {
 
     await cubit.fetchLatestMusic();
     await expectation;
+  });
+
+  test('does not refresh when service already fetched initial data', () async {
+    final service = _MockMusicUpdateService();
+    when(() => service.latest).thenReturn(track);
+    when(() => service.hasFetchedInitial).thenReturn(true);
+
+    final cubit = LatestMusicCubit(service);
+    await cubit.fetchLatestMusic();
+
+    expect(cubit.state.status, LatestMusicStatus.success);
+    expect(cubit.state.track, track);
+    verifyNever(() => service.refresh());
   });
 }

--- a/test/latest_quote_cubit_test.dart
+++ b/test/latest_quote_cubit_test.dart
@@ -14,10 +14,40 @@ void main() {
     const quote = MotivationalQuote(id: 1, text: 't', author: 'a');
     final service = _MockQuoteUpdateService();
     when(() => service.latest).thenReturn(quote);
+    when(() => service.hasFetchedInitial).thenReturn(false);
 
     final cubit = LatestQuoteCubit(service);
 
     expect(cubit.state.status, LatestQuoteStatus.cached);
     expect(cubit.state.quote, quote);
+  });
+
+  test('fetchLatestQuote retrieves quote from service', () async {
+    const quote = MotivationalQuote(id: 1, text: 't', author: 'a');
+    final service = _MockQuoteUpdateService();
+    when(() => service.latest).thenReturn(null);
+    when(service.refresh).thenAnswer((_) async => quote);
+    when(() => service.hasFetchedInitial).thenReturn(false);
+
+    final cubit = LatestQuoteCubit(service);
+    await cubit.fetchLatestQuote();
+
+    expect(cubit.state.status, LatestQuoteStatus.success);
+    expect(cubit.state.quote, quote);
+    verify(service.refresh).called(1);
+  });
+
+  test('does not refresh when service already fetched initial data', () async {
+    const quote = MotivationalQuote(id: 1, text: 't', author: 'a');
+    final service = _MockQuoteUpdateService();
+    when(() => service.latest).thenReturn(quote);
+    when(() => service.hasFetchedInitial).thenReturn(true);
+
+    final cubit = LatestQuoteCubit(service);
+    await cubit.fetchLatestQuote();
+
+    expect(cubit.state.status, LatestQuoteStatus.success);
+    expect(cubit.state.quote, quote);
+    verifyNever(() => service.refresh());
   });
 }


### PR DESCRIPTION
## Summary
- mark first fetch completion in `MusicUpdateService` and `QuoteUpdateService`
- avoid duplicate network calls by checking `hasFetchedInitial` in cubits
- expand cubit tests for music and quote updates

## Testing
- `dart` and `flutter` commands are unavailable in the Codex environment so formatting, analysis and tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_6866c27cc4408324842e575b00b29b64