### PR TITLE
fix(di): wire audio config to player

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -125,7 +125,11 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i578.YoutubeExplode>(
       () => registerModule.youtubeExplode(),
     );
-    gh.lazySingleton<_i501.AudioPlayer>(() => registerModule.audioPlayer());
+    gh.lazySingleton<_i501.AudioPlayer>(
+      () => registerModule.audioPlayer(
+        gh<_i501.AudioLoadConfiguration>(),
+      ),
+    );
     gh.lazySingleton<_i501.AudioLoadConfiguration>(
       () => registerModule.audioLoadConfiguration(),
     );

--- a/lib/core/di/register_module.dart
+++ b/lib/core/di/register_module.dart
@@ -84,7 +84,8 @@ Dio dio(
   YoutubeExplode youtubeExplode() => YoutubeExplode();
 
   @lazySingleton
-  AudioPlayer audioPlayer() => AudioPlayer();
+  AudioPlayer audioPlayer(AudioLoadConfiguration config) =>
+      AudioPlayer(audioLoadConfiguration: config);
 
   @lazySingleton
   AudioLoadConfiguration audioLoadConfiguration() =>


### PR DESCRIPTION
## Summary
- inject `AudioLoadConfiguration` when creating `AudioPlayer`
- update generated registration file accordingly

## Testing
- `dart` and `flutter` not available; skipped formatting and tests

------
https://chatgpt.com/codex/tasks/task_e_6866c4fbeaac83248d0e7a572cf6f136