### PR TITLE
Implement logging of generated music keyword

### DIFF
--- a/backend/app/services/music_keyword_service.py
+++ b/backend/app/services/music_keyword_service.py
@@ -54,7 +54,9 @@ class MusicKeywordService:
                 model=self.settings.GENERATOR_MODEL_NAME,
                 messages=messages,
             )
-            return data["choices"][0]["message"]["content"].strip()
+            keyword = data["choices"][0]["message"]["content"].strip()
+            self.log.info("music_keyword_generated", keyword=keyword)
+            return keyword
         except Exception as e:
             self.log.error("music_keyword_service_error", error=str(e))
             return ""


### PR DESCRIPTION
## Summary
- log generated music keywords in the backend
- formatting and linting executed
- pass unit tests for `MusicKeywordService`

## Testing
- `black backend/app/services/music_keyword_service.py`
- `ruff check backend/app/services/music_keyword_service.py`
- `pytest backend/tests/test_music_keyword_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6866ccaeedb083248cd9da4003f5cfaa