### PR TITLE
Add configurable log level

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,3 +10,4 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/0
 ENVIRONMENT=development
 ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 SENTRY_DSN=
+LOG_LEVEL=INFO

--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,9 @@ gunicorn --preload -w 4 -k uvicorn.workers.UvicornWorker app.main:app
 See `.env.example` for the list of required environment variables including
 `DATABASE_URL` and `OPENROUTER_API_KEY`.
 
+`LOG_LEVEL` controls verbosity for both `logging` and `structlog`. Set
+`LOG_LEVEL=DEBUG` to enable detailed debug logs during development.
+
 ## Background tasks
 
 Motivational quotes are generated automatically using Celery. Ensure Redis is running and start the worker and beat processes alongside Uvicorn:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -46,6 +46,7 @@ class Settings(BaseSettings):
     # Pengaturan Opsional (Contoh: CORS, Sentry)
     ALLOWED_ORIGINS: str = "http://localhost:3000,http://127.0.0.1:3000"
     SENTRY_DSN: str | None = None
+    LOG_LEVEL: str = "INFO"
 
 
 # Buat satu instance settings untuk digunakan di seluruh aplikasi

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,13 +9,15 @@ from fastapi.middleware.cors import CORSMiddleware
 
 
 from app.api.api import api_router
+from app.core.config import settings
 import sentry_sdk
 import structlog
 
 # --- Setup Logging ---
-logging.basicConfig(level=logging.INFO)
+log_level = logging.getLevelName(settings.LOG_LEVEL)
+logging.basicConfig(level=log_level)
 structlog.configure(
-    wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+    wrapper_class=structlog.make_filtering_bound_logger(log_level),
 )
 logger = structlog.get_logger()
 


### PR DESCRIPTION
## Summary
- make log level configurable via `LOG_LEVEL`
- document `LOG_LEVEL` in backend README
- update `.env.example`
- use configured level in `main.py`

## Testing
- `black backend/app/core/config.py backend/app/main.py`
- `ruff check backend/app/core/config.py backend/app/main.py`
- `pytest backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_6866cbbcdd9c8324b3220c14fc19bb0f