### PR TITLE
fix(home): ensure refresh uses Bloc context

### DIFF
--- a/lib/presentation/home/screens/home_screen.dart
+++ b/lib/presentation/home/screens/home_screen.dart
@@ -122,26 +122,27 @@ class _HomeScreenState extends State<HomeScreen> {
           create: (_) => getIt<LatestQuoteCubit>()..fetchLatestQuote(),
         ),
       ],
-      child: Scaffold(
-        appBar: null,
-        body: Column(
-          children: [
-            Expanded(
-              child: RefreshIndicator(
-                onRefresh: () => _onRefresh(context),
-                child: ListView(
-                  padding: const EdgeInsets.all(16),
-                  children: [
-                    const QuoteSection(),
-                    const SizedBox(height: 24),
-                    MusicSection(
-                      onPlay: _playTrack,
-                      loading: _loading,
-                    ),
-                  ],
+      child: Builder(
+        builder: (context) => Scaffold(
+          appBar: null,
+          body: Column(
+            children: [
+              Expanded(
+                child: RefreshIndicator(
+                  onRefresh: () => _onRefresh(context),
+                  child: ListView(
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      const QuoteSection(),
+                      const SizedBox(height: 24),
+                      MusicSection(
+                        onPlay: _playTrack,
+                        loading: _loading,
+                      ),
+                    ],
+                  ),
                 ),
               ),
-            ),
             if (_currentTrack != null)
               PlayerBar(
                 track: _currentTrack!,
@@ -155,7 +156,8 @@ class _HomeScreenState extends State<HomeScreen> {
           ],
         ),
       ),
-    );
+    ),
+  );
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap `Scaffold` inside a `Builder` so `RefreshIndicator` uses the bloc context

## Testing
- `dart format lib/presentation/home/screens/home_screen.dart` *(fails: dart not installed)*
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866d1317e108324b187d5ce51321c0d