### PR TITLE
fix(service): avoid duplicate initial fetch

### DIFF
--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -17,12 +17,17 @@ class MusicUpdateService {
 
   void start() {
     _timer?.cancel();
-    _initialFetchDone = false;
-    _fetch().whenComplete(() => _initialFetchDone = true);
+    if (!_initialFetchDone) {
+      _fetch().whenComplete(() => _initialFetchDone = true);
+    }
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
-  Future<AudioTrack?> refresh() => _fetch();
+  Future<AudioTrack?> refresh() async {
+    final track = await _fetch();
+    _initialFetchDone = true;
+    return track;
+  }
 
   AudioTrack? get latest => _latest ?? _cacheRepository.getLastTrack();
 

--- a/lib/services/quote_update_service.dart
+++ b/lib/services/quote_update_service.dart
@@ -25,12 +25,17 @@ class QuoteUpdateService {
 
   void start() {
     _timer?.cancel();
-    _initialFetchDone = false;
-    _fetch().whenComplete(() => _initialFetchDone = true);
+    if (!_initialFetchDone) {
+      _fetch().whenComplete(() => _initialFetchDone = true);
+    }
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());
   }
 
-  Future<MotivationalQuote?> refresh() => _fetch();
+  Future<MotivationalQuote?> refresh() async {
+    final quote = await _fetch();
+    _initialFetchDone = true;
+    return quote;
+  }
 
   bool get hasFetchedInitial => _initialFetchDone;
 


### PR DESCRIPTION
## Summary
- avoid duplicate network calls in MusicUpdateService
- avoid duplicate network calls in QuoteUpdateService

## Testing
- `dart format lib/services/music_update_service.dart lib/services/quote_update_service.dart` *(fails: `bash: dart: command not found`)*
- `dart analyze` *(fails: `bash: dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866d49616cc832485246700d59ad0b6