### PR TITLE
Improve offline quote handling

### DIFF
--- a/lib/services/quote_update_service.dart
+++ b/lib/services/quote_update_service.dart
@@ -49,8 +49,8 @@ class QuoteUpdateService {
       await _cacheRepository.saveQuote(quote);
       return _lastQuote;
     } catch (_) {
-      // Ignore errors silently
-      return null;
+      // Ignore errors silently, fall back to cached quote
+      return _cacheRepository.getLastQuote();
     }
   }
 

--- a/test/quote_update_service_test.dart
+++ b/test/quote_update_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:dear_flutter/data/datasources/remote/home_api_service.dart';
+import 'package:dear_flutter/domain/entities/motivational_quote.dart';
+import 'package:dear_flutter/domain/repositories/quote_cache_repository.dart';
+import 'package:dear_flutter/services/notification_service.dart';
+import 'package:dear_flutter/services/quote_update_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockApiService extends Mock implements HomeApiService {}
+class _MockCacheRepo extends Mock implements QuoteCacheRepository {}
+class _MockNotificationService extends Mock implements NotificationService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('fetch falls back to cached quote on error', () async {
+    final api = _MockApiService();
+    final cache = _MockCacheRepo();
+    final notif = _MockNotificationService();
+    const cached = MotivationalQuote(id: 1, text: 'q', author: 'a');
+
+    when(() => api.getLatestQuote()).thenThrow(Exception());
+    when(() => cache.getLastQuote()).thenReturn(cached);
+
+    final service = QuoteUpdateService(api, notif, cache);
+    final result = await service.refresh();
+
+    expect(result, cached);
+  });
+}


### PR DESCRIPTION
## Summary
- add cache fallback in `QuoteUpdateService`
- add regression test for service

## Testing
- `flutter test` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6866d687c1e083248bd2fa9a450e12dd