### PR TITLE
Fix OpenRouter song request

### DIFF
--- a/backend/app/api/v1/music.py
+++ b/backend/app/api/v1/music.py
@@ -12,7 +12,7 @@ router = APIRouter()
 log = structlog.get_logger(__name__)
 
 
-@router.get("/recommend", response_model=list[schemas.SongSuggestion])
+@router.get("/recommend", response_model=schemas.SongSuggestion)
 async def recommend_music(
     *,
     mood: str = Query(..., min_length=1),
@@ -21,7 +21,7 @@ async def recommend_music(
     suggestion_service: MusicSuggestionService = Depends(),
 ):
     profile = crud.user_profile.get_by_user_id(db, user_id=current_user.id)
-    return await suggestion_service.suggest_songs(mood=mood, user_profile=profile)
+    return await suggestion_service.suggest_song(mood=mood, user_profile=profile)
 
 
 @router.get("/latest", response_model=schemas.AudioTrack | None)

--- a/backend/app/services/music_suggestion_service.py
+++ b/backend/app/services/music_suggestion_service.py
@@ -34,9 +34,9 @@ class MusicSuggestionService:
             response.raise_for_status()
             return response.json()
 
-    async def suggest_songs(
+    async def suggest_song(
         self, mood: str, user_profile: Optional[UserProfile] = None
-    ) -> List[SongSuggestion]:
+    ) -> SongSuggestion | None:
         profile_summary = ""
         if user_profile:
             emerging = user_profile.emerging_themes or {}
@@ -50,9 +50,9 @@ class MusicSuggestionService:
 
         prompt = dedent(
             f"""
-            Sarankan tiga lagu beserta artis yang cocok untuk mood berikut: {mood}.
+            Sarankan satu lagu beserta artis yang cocok untuk mood berikut: {mood}.
             {profile_summary}
-            Balas dengan JSON list berisi objek {{"title": "...", "artist": "..."}}.
+            Balas dengan JSON {{"title": "...", "artist": "..."}} saja.
             """
         ).strip()
 
@@ -68,9 +68,9 @@ class MusicSuggestionService:
                 content = content[len("```json") :].strip()
             if content.endswith("```"):
                 content = content[:-3].strip()
-            items = json.loads(content)
-            self.log.info("music_suggestion_result", items=items)
-            return [SongSuggestion(**item) for item in items]
+            item = json.loads(content)
+            self.log.info("music_suggestion_result", item=item)
+            return SongSuggestion(**item)
         except Exception as e:
             self.log.error("music_suggestion_error", error=str(e))
-            return []
+            return None

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -65,11 +65,9 @@ async def generate_music_recommendation_task():
         if not keyword:
             return "No keyword generated"
 
-        suggestions = await MusicSuggestionService().suggest_songs(keyword)
-        if not suggestions:
-            return "No suggestions returned"
-
-        suggestion = suggestions[0]
+        suggestion = await MusicSuggestionService().suggest_song(keyword)
+        if not suggestion:
+            return "No suggestion returned"
         youtube_id = ""
         try:
             from youtubesearchpython import VideosSearch

--- a/backend/tests/test_music_api.py
+++ b/backend/tests/test_music_api.py
@@ -13,9 +13,7 @@ async def test_music_suggestion_service_builds_prompt(monkeypatch):
 
     async def fake_call(self, model, messages):
         captured["prompt"] = messages[0]["content"]
-        return {
-            "choices": [{"message": {"content": '[{"title": "t", "artist": "a"}]'}}]
-        }
+        return {"choices": [{"message": {"content": '{"title": "t", "artist": "a"}'}}]}
 
     monkeypatch.setattr(MusicSuggestionService, "_call_openrouter", fake_call)
 
@@ -31,9 +29,9 @@ async def test_music_suggestion_service_builds_prompt(monkeypatch):
         last_analyzed=datetime.utcnow(),
     )
 
-    result = await service.suggest_songs("happy", profile)
+    result = await service.suggest_song("happy", profile)
 
-    assert result[0].title == "t"
+    assert result.title == "t"
     assert "happy" in captured["prompt"]
     assert "rock" in captured["prompt"]
 
@@ -44,9 +42,9 @@ def test_music_recommend_returns_suggestions(client, monkeypatch):
     async def fake_suggest(self, mood, user_profile=None):
         captured["mood"] = mood
         captured["profile"] = user_profile
-        return [SongSuggestion(title="t", artist="a")]
+        return SongSuggestion(title="t", artist="a")
 
-    monkeypatch.setattr(MusicSuggestionService, "suggest_songs", fake_suggest)
+    monkeypatch.setattr(MusicSuggestionService, "suggest_song", fake_suggest)
 
     client_app, session_local = client
     db = session_local()
@@ -58,6 +56,6 @@ def test_music_recommend_returns_suggestions(client, monkeypatch):
 
     resp = client_app.get("/api/v1/music/recommend?mood=joy")
     assert resp.status_code == 200
-    assert resp.json()[0]["title"] == "t"
+    assert resp.json()["title"] == "t"
     assert captured["mood"] == "joy"
     assert captured["profile"] is not None

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -31,7 +31,7 @@ async def test_generate_music_recommendation_task_sets_track(monkeypatch, temp_s
         return "lofi"
 
     async def fake_suggest(self, mood):
-        return [SongSuggestion(title="Song", artist="Artist")]
+        return SongSuggestion(title="Song", artist="Artist")
 
     class DummySearch:
         def __init__(self, query, limit=1):
@@ -42,7 +42,7 @@ async def test_generate_music_recommendation_task_sets_track(monkeypatch, temp_s
             return {"result": [{"id": "ytid"}]}
 
     monkeypatch.setattr(MusicKeywordService, "generate_keyword", fake_keyword)
-    monkeypatch.setattr(MusicSuggestionService, "suggest_songs", fake_suggest)
+    monkeypatch.setattr(MusicSuggestionService, "suggest_song", fake_suggest)
     monkeypatch.setattr("youtubesearchpython.VideosSearch", DummySearch)
 
     await generate_music_recommendation_task()


### PR DESCRIPTION
## Summary
- request only one song from OpenRouter
- update tasks and endpoint for the single song flow
- adjust unit tests for new return type

## Testing
- `ruff check backend/app/services/music_suggestion_service.py backend/app/api/v1/music.py backend/app/tasks.py backend/tests/test_music_api.py backend/tests/test_tasks.py`
- `black backend/tests/test_music_api.py backend/tests/test_tasks.py backend/app/services/music_suggestion_service.py backend/app/api/v1/music.py backend/app/tasks.py --check`
- `pytest -q backend/tests/test_music_api.py backend/tests/test_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_6866defc5cbc8324b50fa37525f83177