### PR TITLE
Add delayed start option for update services

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ notification is shown and tapping it opens the quote detail screen.
 The backend runs a Celery task named `generate_music_recommendation_task`
 every 15 minutes. It stores its result in `/music/latest`, and the Flutter app
 polls this endpoint on the same schedule to update the home screen with the
-newest track.
+newest track. The quote and music update services expose a
+`start({bool immediateFetch = true})` method. Passing `immediateFetch: false`
+skips the initial network call so only the periodic timer runs. The home screen
+fetches `/home-feed` on launch to obtain the latest quote and track.
 
 A lightweight `/home-feed` endpoint is also available. It returns the most
 recent motivational quote and music track in a single JSON object:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -31,8 +31,8 @@ Future<void> main() async {
 
   // Delay starting services until after the first frame to prevent skipped-frame warnings
   WidgetsBinding.instance.addPostFrameCallback((_) {
-    getIt<QuoteUpdateService>().start();
-    getIt<MusicUpdateService>().start();
+    getIt<QuoteUpdateService>().start(immediateFetch: false);
+    getIt<MusicUpdateService>().start(immediateFetch: false);
   });
 }
 

--- a/lib/services/music_update_service.dart
+++ b/lib/services/music_update_service.dart
@@ -15,9 +15,9 @@ class MusicUpdateService {
   bool _initialFetchDone = false;
   MusicUpdateService(this._apiService, this._cacheRepository);
 
-  void start() {
+  void start({bool immediateFetch = true}) {
     _timer?.cancel();
-    if (!_initialFetchDone) {
+    if (immediateFetch && !_initialFetchDone) {
       _fetch().whenComplete(() => _initialFetchDone = true);
     }
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());

--- a/lib/services/quote_update_service.dart
+++ b/lib/services/quote_update_service.dart
@@ -23,9 +23,9 @@ class QuoteUpdateService {
   MotivationalQuote? get latest =>
       _lastQuote ?? _cacheRepository.getLastQuote();
 
-  void start() {
+  void start({bool immediateFetch = true}) {
     _timer?.cancel();
-    if (!_initialFetchDone) {
+    if (immediateFetch && !_initialFetchDone) {
       _fetch().whenComplete(() => _initialFetchDone = true);
     }
     _timer = Timer.periodic(const Duration(minutes: 15), (_) => _fetch());


### PR DESCRIPTION
## Summary
- add `immediateFetch` parameter to `MusicUpdateService.start` and `QuoteUpdateService.start`
- invoke `start(immediateFetch: false)` on app startup
- document the optional fetch behavior in README

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e367fe548324ab9b62cb6a5b4a61