### PR TITLE
Add celery beat worker to Render config

### DIFF
--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -33,5 +33,14 @@ services:
     envVars:
       - fromGroup: dear-diary-secrets
 
+  - type: worker
+    name: beat
+    runtime: docker
+    repo: https://github.com/tanerizawa/server.git
+    autoDeploy: true
+    dockerCommand: "celery -A app.celery_app beat --loglevel=info"
+    envVars:
+      - fromGroup: dear-diary-secrets
+
 envVarGroups:
   - name: dear-diary-secrets


### PR DESCRIPTION
## Summary
- configure Render to run a celery beat worker so scheduled tasks execute

## Issues
- None

## Files Affected
- `backend/render.yaml`

## Testing
- `black . --check`
- `ruff check .`
- ⚠️ `dart format` and `dart analyze` were skipped because the Flutter SDK is not available in the Codex environment

------
https://chatgpt.com/codex/tasks/task_e_6866ef3562dc832484b3448f828eb8b6