### PR TITLE
Fix base URL config and openrouter settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ The backend reads several variables from the environment. Provide a
 - `DATABASE_URL` – SQLAlchemy database URL (defaults to SQLite `sqlite:///./test.db`).
 - `SECRET_KEY` – secret key used for JWT creation (defaults to `supersecretkey`).
 - `OPENROUTER_API_KEY` – API key for the OpenRouter chat and music recommendation service (required for `/music/recommend`).
+- `OPENROUTER_BASE_URL` – base URL for OpenRouter API.
 - `PLANNER_MODEL_NAME` – model name used by the conversation planner.
 - `GENERATOR_MODEL_NAME` – model name used by the response generator.
 - `APP_SITE_URL` – site URL sent in OpenRouter requests for identification.
@@ -220,6 +221,7 @@ Create a `.env` file inside the `backend/` directory and define these variables:
 
 ```bash
 OPENROUTER_API_KEY=<your-key>
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 PLANNER_MODEL_NAME=mistralai/mistral-7b-instruct
 GENERATOR_MODEL_NAME=google/gemma-7b-it
 APP_SITE_URL=https://yourdomain.com

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL=sqlite:///./test.db
 SECRET_KEY=supersecretkey
 OPENROUTER_API_KEY=
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1  # TODO: 2025-07-04 Add config for OpenRouter host
 PLANNER_MODEL_NAME=deepseek/deepseek-chat-v3-0324
 GENERATOR_MODEL_NAME=deepseek/deepseek-chat-v3-0324
 APP_SITE_URL=http://localhost

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
 
     # Kredensial & Konfigurasi Layanan Eksternal
     OPENROUTER_API_KEY: str | None = None
+    OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
     PLANNER_MODEL_NAME: str = "deepseek/deepseek-chat-v3-0324"
     GENERATOR_MODEL_NAME: str = "deepseek/deepseek-chat-v3-0324"
 

--- a/backend/app/services/generator_service.py
+++ b/backend/app/services/generator_service.py
@@ -10,7 +10,7 @@ from app.schemas.plan import ConversationPlan
 class GeneratorService:
     def __init__(self, settings: Settings = Depends(lambda: settings)):
         self.settings = settings
-        self.api_base_url = "https://openrouter.ai/api/v1"
+        self.api_base_url = self.settings.OPENROUTER_BASE_URL
         self.log = structlog.get_logger(__name__)
 
         # Teknik komunikasi yang tersedia

--- a/backend/app/services/music_keyword_service.py
+++ b/backend/app/services/music_keyword_service.py
@@ -14,7 +14,7 @@ from app.models.journal import Journal
 class MusicKeywordService:
     def __init__(self, settings: Settings = Depends(lambda: settings)):
         self.settings = settings
-        self.api_base_url = "https://openrouter.ai/api/v1"
+        self.api_base_url = self.settings.OPENROUTER_BASE_URL
         self.log = structlog.get_logger(__name__)
 
     async def _call_openrouter(

--- a/backend/app/services/music_suggestion_service.py
+++ b/backend/app/services/music_suggestion_service.py
@@ -16,7 +16,7 @@ class MusicSuggestionService:
 
     def __init__(self, settings: Settings = Depends(lambda: settings)):
         self.settings = settings
-        self.api_base_url = "https://openrouter.ai/api/v1"
+        self.api_base_url = self.settings.OPENROUTER_BASE_URL
         self.log = structlog.get_logger(__name__)
 
     async def _call_openrouter(

--- a/backend/app/services/planner_service.py
+++ b/backend/app/services/planner_service.py
@@ -13,7 +13,7 @@ from app.models.user_profile import UserProfile  # pastikan path ini valid
 class PlannerService:
     def __init__(self, settings: Settings = Depends(lambda: settings)):
         self.settings = settings
-        self.api_base_url = "https://openrouter.ai/api/v1"
+        self.api_base_url = self.settings.OPENROUTER_BASE_URL
         self.log = structlog.get_logger(__name__)
 
     async def _call_openrouter(

--- a/backend/app/services/quote_generation_service.py
+++ b/backend/app/services/quote_generation_service.py
@@ -10,7 +10,7 @@ from app.core.config import Settings, settings
 class QuoteGenerationService:
     def __init__(self, settings: Settings = Depends(lambda: settings)):
         self.settings = settings
-        self.api_base_url = "https://openrouter.ai/api/v1"
+        self.api_base_url = self.settings.OPENROUTER_BASE_URL
         self.log = structlog.get_logger(__name__)
 
     async def _call_openrouter(

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,3 +1,3 @@
 {
-  "API_BASE_URL": "http://10.0.2.2:8000"
+  "API_BASE_URL": "http://10.0.2.2:8000/api/v1/"  // TODO: 2025-07-04 align with backend prefix
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,3 +1,3 @@
 {
-  "API_BASE_URL": "https://server-qp6y.onrender.com"
+  "API_BASE_URL": "https://server-qp6y.onrender.com/api/v1/"  // TODO: 2025-07-04 ensure trailing path for API
 }

--- a/docs/CONFIG_NOTES.md
+++ b/docs/CONFIG_NOTES.md
@@ -9,3 +9,5 @@ This file tracks configuration updates across the project.
 [YYYY-MM-DD] Author - Reason for change
 ```
 
+[2025-07-04] Codex - Added OPENROUTER_BASE_URL to .env for configurable OpenRouter host
+


### PR DESCRIPTION
## Summary
- add OPENROUTER_BASE_URL setting to backend config
- use the new setting across backend services
- update environment example and README
- fix API_BASE_URL paths in dev/prod configs
- document config change

## Testing
- `ruff check .`
- `black --check backend/app/services/*.py backend/app/core/config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6867907f4a4883248ef4e19619821d94