### PR TITLE
Update README for Render deployment

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -51,3 +51,21 @@ performs a lightweight YouTube search to resolve a `youtube_id`, and finally
 stores the resulting track in the `musictracks` table. The most recent entry can
 be fetched from `/music/latest`, which the Flutter app polls every 15 minutes.
 
+## Deploying to Render
+
+`render.yaml` defines a Postgres database, a Redis instance and three Docker
+services: the FastAPI `web` container along with separate Celery `worker` and
+`beat` processes. All of them share an environment variable group named
+`dear-diary-secrets`.
+
+1. In the Render dashboard choose **New > Blueprint** and select this repository.
+   Render reads `backend/render.yaml` and creates the services.
+2. Create an environment group called **dear-diary-secrets** and add:
+   - `OPENROUTER_API_KEY` – your OpenRouter token.
+   - `DATABASE_URL` – connection string for the Postgres service.
+   - `REDIS_HOST` and `REDIS_PORT` – host and port of the Redis service,
+     usually `redis` and `6379`.
+3. Attach the group to the `web`, `worker` and `beat` services.
+
+Deploying the blueprint runs Gunicorn for the API and starts both Celery
+processes automatically, so scheduled tasks work without extra steps.


### PR DESCRIPTION
## Summary
- document how to deploy the FastAPI backend on Render
- mention creating the `dear-diary-secrets` env group and setting required variables
- note that Celery worker and beat services run as described in `render.yaml`

## Testing
- `black --check backend`
- `ruff check backend`
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6867951164b8832484d56af6ae7bf054