### PR TITLE
Fix imports for home screen player test

### DIFF
--- a/test/home_screen_player_test.dart
+++ b/test/home_screen_player_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:audio_service/audio_service.dart';
+import 'package:rxdart/rxdart.dart';
 
 // Import the test helper
 import '../helpers/test_helper.dart';


### PR DESCRIPTION
## Summary
- fix missing imports in `home_screen_player_test.dart`

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868031c28608324b4d8b10fa3afb65d